### PR TITLE
Add support for simple JSON 

### DIFF
--- a/R/query-string.R
+++ b/R/query-string.R
@@ -8,29 +8,36 @@ queryStringFilter <- function(req){
 #' @importFrom utils URLdecode
 #' @noRd
 parseQS <- function(qs){
-  if (is.null(qs) || length(qs) == 0 || qs == ""){
+  # Is there data in the request?
+  if (is.null(qs) || length(qs) == 0 || qs == "") {
     return(list())
   }
-  if (stri_startswith_fixed(qs, "?")){
+ # Is it JSON data?
+  if (stri_startswith_fixed(qs, "{")) {
     qs <- substr(qs, 2, nchar(qs))
+    #TODO: add handling of JSON
+  } else {
+    # If not handle it as & separated strings
+    if (stri_startswith_fixed(qs, "?")) {
+      qs <- substr(qs, 2, nchar(qs))
+    }
+
+    qs <- gsub("+", " ", qs, fixed = TRUE)
+
+    parts <- strsplit(qs, "&", fixed = TRUE)[[1]]
+    kv <- strsplit(parts, "=", fixed = TRUE)
+    kv <- kv[sapply(kv, length) == 2] # Ignore incompletes
+
+    keys <- sapply(kv, "[[", 1)
+    keys <- unname(sapply(keys, URLdecode))
+
+    vals <- sapply(kv, "[[", 2)
+    vals[is.na(vals)] <- ""
+    vals <- unname(sapply(vals, URLdecode))
+
+    ret <- as.list(vals)
+    names(ret) <- keys
   }
-
-  qs <- gsub("+", " ", qs, fixed=TRUE)
-
-  parts <- strsplit(qs, "&", fixed=TRUE)[[1]]
-  kv <- strsplit(parts, "=", fixed=TRUE)
-  kv <- kv[sapply(kv, length) == 2] # Ignore incompletes
-
-  keys <- sapply(kv, "[[", 1)
-  keys <- unname(sapply(keys, URLdecode))
-
-  vals <- sapply(kv, "[[", 2)
-  vals[is.na(vals)] <- ""
-  vals <- unname(sapply(vals, URLdecode))
-
-  ret <- as.list(vals)
-  names(ret) <- keys
-
   ret
 }
 

--- a/R/query-string.R
+++ b/R/query-string.R
@@ -14,9 +14,9 @@ parseQS <- function(qs){
   }
  # Is it JSON data?
   if (stri_startswith_fixed(qs, "{")) {
-    qs <- substr(qs, 2, nchar(qs))
-    #TODO: add handling of JSON
-  } else {
+    # Handle JSON with jsonlite
+    ret <- jsonlite::fromJSON(qs)
+    } else {
     # If not handle it as & separated strings
     if (stri_startswith_fixed(qs, "?")) {
       qs <- substr(qs, 2, nchar(qs))

--- a/R/response.R
+++ b/R/response.R
@@ -32,7 +32,7 @@ PlumberResponse <- R6Class(
         body = self$body
       )
     },
-    # TODO: support multiple setCoookies per response
+    # TODO: support multiple setCookies per response
     setCookie = function(name, value, path){
       # TODO: support expiration
       # TODO: support HTTP-only

--- a/tests/testthat/test-querystring.R
+++ b/tests/testthat/test-querystring.R
@@ -13,3 +13,8 @@ test_that("incomplete query strings are ignored", {
   expect_equivalent(parseQS("a="), list()) # It's technically a named list()
   expect_equal(parseQS("a=1&b=&c&d=1"), list(a="1", d="1"))
 })
+
+test_that("JSON is consumed", {
+  expect_equivalent(parseQS("a="), list()) # It's technically a named list()
+  expect_equal(parseQS("{'a'='1'}"), list(a = "1"))
+})

--- a/tests/testthat/test-querystring.R
+++ b/tests/testthat/test-querystring.R
@@ -16,5 +16,5 @@ test_that("incomplete query strings are ignored", {
 
 test_that("JSON is consumed", {
   expect_equivalent(parseQS("a="), list()) # It's technically a named list()
-  expect_equal(parseQS("{'a'='1'}"), list(a = "1"))
+  expect_equal(parseQS('{"a":"1"}'), list(a = "1"))
 })


### PR DESCRIPTION
This adds basic JSON support to solve issue #50. Following the example in the readme, the following will work after adding this patch:

     curl --data '{"a":4, "b":5}' http://localhost:8000/sum

Since the call is on jsonlite to parse the content of the querystring, more complex JSON should also be possible, but I have not tested that yet.
