### PR TITLE
Add an entrypoint for width to the png processor

### DIFF
--- a/R/processor-image.R
+++ b/R/processor-image.R
@@ -24,7 +24,12 @@ PlumberProcessor$new(
   function(req, res, data){
     t <- tempfile()
     data$file <- t
-    png(t)
+    if(!is.null(req$width)) {
+      width <- req$width
+    } else {
+      req$width <- 480
+    }
+    png(t, width = req$width)
   },
   function(val, req, res, data){
     dev.off()


### PR DESCRIPTION
I'd like to expose parameters like `width` to [the `png` processor](https://github.com/trestletech/plumber/blob/c82f6b3418858b07c6ea60f19c175967fc6fd708/R/processor-image.R#L23).

My idea here is to use a `filter` like,

```r
#* @filter plot-width
function(req, width=480){
  req$width <- as.numeric(width)
  forward()
}
```

I'm still figuring out a nice general way to expose processor params anyone have ideas about how to do that?