### PR TITLE
Provide explicit context for new environment before `source`ing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ r_github_packages:
   - jimhester/covr
 after_success:
   - Rscript -e 'library(covr);codecov()'
+after_failure:
+  - ./travis-tool.sh dump_logs
 r_packages:
   - PKI
 warnings_are_errors: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Package: plumber
 Type: Package
 Title: An API Generator for R
 Version: 0.3.2
-Date: 2017-01-18
+Date: 2017-04-05
 Authors@R: c(
   person(family="Trestle Technology, LLC", role="aut", email="cran@trestletech.com"),
   person("Jeff", "Allen", role="cre", email="cran@trestletech.com"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Encoding: UTF-8
 Package: plumber
 Type: Package
 Title: An API Generator for R
-Version: 0.3.1
-Date: 2016-09-05
+Version: 0.3.2
+Date: 2017-01-18
 Authors@R: c(
   person(family="Trestle Technology, LLC", role="aut", email="cran@trestletech.com"),
   person("Jeff", "Allen", role="cre", email="cran@trestletech.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+plumber 0.3.2
+--------------------------------------------------------------------------------
+* `source()` the referenced R file to plumb inside of a new environment that 
+  inherits directly from the GlobalEnv. This provides more explicit control over
+  exactly how this environment should behave.
+
 plumber 0.3.1
 --------------------------------------------------------------------------------
 * Add a method to consume JSON on post (you can still send a query string in

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -46,7 +46,7 @@ plumber <- R6Class(
       self$filters <- c(self$filters, PlumberFilter$new("cookieParser", cookieFilter, private$envir, private$defaultSerializer, NULL, NULL))
 
       private$filename <- file
-      private$envir <- new.env()
+      private$envir <- new.env(parent=.GlobalEnv)
 
       if (!is.null(file)){
         private$fileLines <- readLines(file)

--- a/tests/testthat/files/serializer.R
+++ b/tests/testthat/files/serializer.R
@@ -15,7 +15,7 @@ function(req, res){
 #* @filter foo2
 function(req, res, type=""){
   if (type == "json"){
-    res$serializer <- jsonSerializer()
+    res$serializer <- plumber:::jsonSerializer()
   }
   forward()
 }


### PR DESCRIPTION
Fixes #48 