### PR TITLE
entrypoint.R support.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 plumber 0.4.0
 --------------------------------------------------------------------------------
 * BREAKING: Listen on localhost instead of listening publicly by default.
+* Add support for `entrypoint.R` when `plumb()`ing a directory. If this file 
+  exists, it is expected to return a Plumber router representing the API
+  contained in this directory. If it doesn't exist, the bahvior is unaltered.
 
 plumber 0.3.3
 --------------------------------------------------------------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ plumber 0.4.0
 * Add support for `entrypoint.R` when `plumb()`ing a directory. If this file 
   exists, it is expected to return a Plumber router representing the API
   contained in this directory. If it doesn't exist, the bahvior is unaltered.
+  If both `plumber.R` and `entrypoint.R` exist, `entrypoint.R` takes precedence.
 
 plumber 0.3.3
 --------------------------------------------------------------------------------

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -386,6 +386,17 @@ plumb <- function(file, dir){
     dir <- sub("/$", "", dir)
     file <- file.path(dir,"plumber.R")
   }
-  plumber$new(file)
+
+  if (file.exists(file.path(dir, "entrypoint.R"))){
+    old <- setwd(dir)
+    on.exit(setwd(old))
+
+    # Expect that entrypoint will provide us with the router
+    x <- source("entrypoint.R")
+    # source returns a list with value and visible elements, we want the (visible) value object.
+    x$value
+  } else {
+    plumber$new(file)
+  }
 }
 

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -21,7 +21,9 @@ enumerateVerbs <- function(v){
 #' details on the methods available on this object.
 #' @param file The file to parse as the plumber router definition
 #' @param dir The directory containing the `plumber.R` file to parse as the
-#'   plumber router definition
+#'   plumber router definition. Alternatively, if an `entrypoint.R` file is
+#'   found, it will take precedence and be responsible for returning a runnable
+#'   Plumber router.
 #' @include globals.R
 #' @include serializer-json.R
 #' @include parse-block.R
@@ -384,19 +386,32 @@ plumb <- function(file, dir){
     stop("plumber needs only one of a file or a directory with a `plumber.R` or `entrypoint.R` file in its root.")
   } else if (missing(file)){
     dir <- sub("/$", "", dir)
-    file <- file.path(dir,"plumber.R")
+    file <- file.path(dir, "plumber.R")
   }
 
-  if (file.exists(file.path(dir, "entrypoint.R"))){
+  if (!missing(dir) && file.exists(file.path(dir, "entrypoint.R"))){
+    # Dir was specified and we found an entrypoint.R
+
     old <- setwd(dir)
     on.exit(setwd(old))
 
     # Expect that entrypoint will provide us with the router
     x <- source("entrypoint.R")
+
     # source returns a list with value and visible elements, we want the (visible) value object.
-    x$value
-  } else {
+    pr <- x$value
+    if (!("plumber" %in% class(pr))){
+      stop("entrypoint.R must return a runnable Plumber router.")
+    }
+
+    pr
+  } else if (file.exists(file)) {
+    # Plumber file found
+
     plumber$new(file)
+  } else {
+    # Couldn't find the Plumber file nor an entrypoint
+    stop("File does not exist: ", file)
   }
 }
 

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -381,7 +381,7 @@ plumber <- R6Class(
 #' @export
 plumb <- function(file, dir){
   if(!xor(missing(file), missing(dir))){
-    stop("plumber needs only one of a file or a directory with a `plumber.R` file in its root.")
+    stop("plumber needs only one of a file or a directory with a `plumber.R` or `entrypoint.R` file in its root.")
   } else if (missing(file)){
     dir <- sub("/$", "", dir)
     file <- file.path(dir,"plumber.R")

--- a/inst/examples/12-entrypoint/entrypoint.R
+++ b/inst/examples/12-entrypoint/entrypoint.R
@@ -1,0 +1,5 @@
+
+pr <- plumb("myplumberapi.R")
+pr$addGlobalProcessor(sessionCookie("secret", "cookieName"))
+
+pr

--- a/inst/examples/12-entrypoint/myplumberapi.R
+++ b/inst/examples/12-entrypoint/myplumberapi.R
@@ -1,0 +1,9 @@
+#* @get /counter
+function(req){
+  count <- 0
+  if (!is.null(req$session$counter)){
+    count <- as.numeric(req$session$counter)
+  }
+  req$session$counter <- count + 1
+  return(paste0("This is visit #", count))
+}

--- a/man/plumber.Rd
+++ b/man/plumber.Rd
@@ -14,7 +14,10 @@ plumb(file, dir)
 \arguments{
 \item{file}{The file to parse as the plumber router definition}
 
-\item{dir}{The directory containing the \code{plumber.R} file to parse as the plumber router definition}
+\item{dir}{The directory containing the \code{plumber.R} file to parse as the
+plumber router definition. Alternatively, if an \code{entrypoint.R} file is
+found, it will take precedence and be responsible for returning a runnable
+Plumber router.}
 }
 \description{
 Routers are the core request handler in plumber. A router is responsible for

--- a/tests/testthat/files/entrypoint-bad/entrypoint.R
+++ b/tests/testthat/files/entrypoint-bad/entrypoint.R
@@ -1,0 +1,1 @@
+"I DON'T KNOW WHAT TO DO!!"

--- a/tests/testthat/files/entrypoint-bad/plumber.R
+++ b/tests/testthat/files/entrypoint-bad/plumber.R
@@ -1,0 +1,5 @@
+#* @get /
+#* @serializer fake
+function(){
+  13
+}

--- a/tests/testthat/files/entrypoint/entrypoint.R
+++ b/tests/testthat/files/entrypoint/entrypoint.R
@@ -1,0 +1,16 @@
+plumber::addSerializer("fake", function(){
+  function(val, req, res, errorHandler){
+    tryCatch({
+      json <- jsonlite::toJSON(val)
+
+      res$setHeader("Content-Type", "application/json")
+      res$body <- paste0("FAKE", json)
+
+      return(res$toResponse())
+    }, error=function(e){
+      errorHandler(req, res, e)
+    })
+  }
+})
+
+plumber$new("./plumber.R")

--- a/tests/testthat/files/entrypoint/plumber.R
+++ b/tests/testthat/files/entrypoint/plumber.R
@@ -1,0 +1,5 @@
+#* @get /
+#* @serializer fake
+function(){
+  13
+}

--- a/tests/testthat/test-plumber.R
+++ b/tests/testthat/test-plumber.R
@@ -39,7 +39,7 @@ test_that("Invalid file fails gracefully", {
   expect_error(plumber$new("asdfsadf"), regexp="File does not exist.*asdfsadf")
 })
 
-test_that("#plumb accepts a directory with a `plumber.R` file", {
+test_that("plumb accepts a directory with a `plumber.R` file", {
   # works without trailing slash
   r <- plumb(dir = 'files')
   expect_equal(length(r$endpoints), 1)
@@ -56,6 +56,23 @@ test_that("#plumb accepts a directory with a `plumber.R` file", {
   expect_error(plumb(), regexp="plumber needs only one of a file or a directory*")
   # errors when both dir and file are given
   expect_error(plumb(file="files/endpoints.R", dir="files"), regexp="plumber needs only one of a file or a directory*")
+})
+
+test_that("plumb() a dir leverages `entrypoint.R`", {
+  expect_null(plumber:::.globals$serializers$fake, "This just that your Plumber environment is dirty. Restart your R session.")
+
+  # works without trailing slash
+  # works with trailing slash
+  r <- plumb(dir = 'files/entrypoint/')
+  expect_equal(length(r$endpoints), 1)
+  expect_equal(length(r$endpoints[[1]]), 1)
+
+  # A global serializer was added by entrypoint.R before parsing
+  expect_true(!is.null(plumber:::.globals$serializers$fake))
+
+  # Clean up after ourselves
+  gl <- plumber:::.globals
+  gl$serializers["fake"] <- NULL
 })
 
 test_that("Empty endpoints error", {

--- a/tests/testthat/test-plumber.R
+++ b/tests/testthat/test-plumber.R
@@ -61,8 +61,6 @@ test_that("plumb accepts a directory with a `plumber.R` file", {
 test_that("plumb() a dir leverages `entrypoint.R`", {
   expect_null(plumber:::.globals$serializers$fake, "This just that your Plumber environment is dirty. Restart your R session.")
 
-  # works without trailing slash
-  # works with trailing slash
   r <- plumb(dir = 'files/entrypoint/')
   expect_equal(length(r$endpoints), 1)
   expect_equal(length(r$endpoints[[1]]), 1)
@@ -73,6 +71,10 @@ test_that("plumb() a dir leverages `entrypoint.R`", {
   # Clean up after ourselves
   gl <- plumber:::.globals
   gl$serializers["fake"] <- NULL
+})
+
+test_that("bad `entrypoint.R`s throw", {
+  expect_error(plumb(dir = 'files/entrypoint-bad/'), "runnable Plumber router")
 })
 
 test_that("Empty endpoints error", {


### PR DESCRIPTION
Add support for the `entrypoint.R` file which can be used when parsing a directory. In that case, rather than naively trying to parse the plumber.R file in the directory, we'll entrust the entrypoint.R to generate a plumber router for us. Presumably a user would do this in order to do some extra configuration on the front-end.

@scottmmjackson do you mind reviewing?

Closes #106