### PR TITLE
Add helper for comparing functions.

### DIFF
--- a/tests/testthat/helper-compare-serializer.R
+++ b/tests/testthat/helper-compare-serializer.R
@@ -1,0 +1,24 @@
+# We can't naively compare serializers using expect equal without losing codecov results.
+# codecov modifies the source of the functions so they are no longer comparable when
+# deparsed, which causes the tests to fail only for codecov.
+# Here we'll make our own comparison function.
+# covr adds lines to measure coverage but also adds brackets to capture expressions differently.
+# So we use this rough heuristic to just take the word characters without whitespace and compare
+# those. It's not perfect, but it would almost always fail if you were comparing to different
+# functions.
+expect_equal_functions <- function(object, expected){
+  do <- deparse(object)
+  de <- deparse(expected)
+
+  do <- gsub(".*covr:::count.*", NA, do)
+  do <- do[!is.na(do)]
+  do <- paste(do, collapse="")
+  do <- gsub("[^\\w]", "", do, perl=TRUE)
+
+  de <- gsub(".*covr:::count.*", NA, de)
+  de <- de[!is.na(de)]
+  de <- paste(de, collapse="")
+  de <- gsub("[^\\w]", "", de, perl=TRUE)
+
+  expect_equal(do, de)
+}

--- a/tests/testthat/test-parse-block.R
+++ b/tests/testthat/test-parse-block.R
@@ -10,7 +10,7 @@ test_that("parseBlock works", {
   expect_equal(b$path, "/")
   expect_equal(b$verbs, c("POST", "GET"))
   expect_equal(b$filter, "test")
-  expect_equal(b$serializer, jsonSerializer())
+  expect_equal_functions(b$serializer, jsonSerializer())
 })
 
 test_that("Block can't be multiple mutually exclusive things", {

--- a/tests/testthat/test-serializer.R
+++ b/tests/testthat/test-serializer.R
@@ -76,11 +76,11 @@ test_that("Overridden serializers apply on filters and endpoints", {
 
   res <- PlumberResponse$new()
   expect_equal(r$serve(make_req("GET", "/short-json"), res)$body, jsonlite::toJSON("JSON"))
-  expect_equal(res$serializer, jsonSerializer())
+  expect_equal_functions(res$serializer, jsonSerializer())
 
   res <- PlumberResponse$new()
   expect_equal(r$serve(make_req("GET", "/short-html"), res)$body, "HTML")
-  expect_equal(res$serializer, htmlSerializer())
+  expect_equal_functions(res$serializer, htmlSerializer())
 
   res <- PlumberResponse$new()
   body <- r$serve(make_req("GET", "/single-arg-ser"), res)$body


### PR DESCRIPTION
Otherwise codecov fails.