### PR TITLE
Set ByteCompile on installation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,3 @@
-
 Encoding: UTF-8
 Package: plumber
 Type: Package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,3 +1,4 @@
+
 Encoding: UTF-8
 Package: plumber
 Type: Package
@@ -26,6 +27,7 @@ Imports:
     httpuv (>= 1.2.3),
     crayon
 LazyData: TRUE
+ByteCompile: TRUE
 Suggests:
     testthat (>= 0.11.0),
     XML,


### PR DESCRIPTION
At UseR!2017 @csgillespie emphasized the importance of adding the BytCompile flag to packages. It is a an easy way to increase performance of the package. See [Efficient R Programming](https://csgillespie.github.io/efficientR/7-4-the-byte-compiler.html) for reference.