### PR TITLE
Parsing query string arrays

### DIFF
--- a/R/query-string.R
+++ b/R/query-string.R
@@ -29,6 +29,16 @@ parseQS <- function(qs){
   ret <- as.list(vals)
   names(ret) <- keys
 
+  # If duplicates, combine
+  combine_elements <- function(name){
+    unname(unlist(ret[names(ret)==name]))
+  }
+
+  unique_names <- unique(names(ret))
+
+  ret <- lapply(unique_names, combine_elements)
+  names(ret) <- unique_names
+
   ret
 }
 

--- a/tests/testthat/test-querystring.R
+++ b/tests/testthat/test-querystring.R
@@ -20,3 +20,7 @@ test_that("incomplete query strings are ignored", {
   expect_equivalent(parseQS("a="), list()) # It's technically a named list()
   expect_equal(parseQS("a=1&b=&c&d=1"), list(a="1", d="1"))
 })
+
+test_that("query strings with duplicates are made into vectors", {
+  expect_equal(parseQS("a=1&a=2&a=3&a=4"), list(a=c("1", "2", "3", "4")))
+})


### PR DESCRIPTION
When a query string has multiple of the same element. For example ‘keyword=hello&keyword=goodbye’, these form an array and should probably be parsed in R as a vector e.g. keyword = c(‘hello’, ‘goodbye’). 

Currently having multiple elements of the same name in a query string just raises an error. The pull request aims to fix this and has added a test for it.