### PR TITLE
Only run querystring and post body filters once.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,13 @@
-plumber 0.4.1
+plumber 0.4.3
+--------------------------------------------------------------------------------
+* BUGFIX: properly handle named query string and post body arguments in 
+  mounted subrouters.
+* Enable `ByteCompile` flag
+* Set working directory for DigitalOcean APIs.
+* Respect `setErrorHandler`
+* BUGFIX: export `PlumberStatic`
+
+plumber 0.4.2
 --------------------------------------------------------------------------------
 * Development version for 0.4.2. Will be working to move to even/odd release
   cycles, but I had prematurely bumped to 0.4.0 so that one might get skipped,

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -480,6 +480,7 @@ plumber <- R6Class(
       # old data here.
       # Set the arguments to an empty list
       req$args <- list()
+      req$.internal <- new.env()
 
       res <- PlumberResponse$new(private$serializer)
       self$serve(req, res)

--- a/R/post-body.R
+++ b/R/post-body.R
@@ -1,8 +1,12 @@
 postBodyFilter <- function(req){
-  body <- req$rook.input$read_lines()
-  args <- parseBody(body)
-  req$postBody <- body
-  req$args <- c(req$args, args)
+  handled <- req$.internal$postBodyHandled
+  if (is.null(handled) || handled != TRUE){
+    body <- req$rook.input$read_lines()
+    args <- parseBody(body)
+    req$postBody <- body
+    req$args <- c(req$args, args)
+    req$.internal$postBodyHandled <- TRUE
+  }
   forward()
 }
 

--- a/R/query-string.R
+++ b/R/query-string.R
@@ -1,7 +1,11 @@
 queryStringFilter <- function(req){
-  qs <- req$QUERY_STRING
-  args <- parseQS(qs)
-  req$args <- c(req$args, args)
+  handled <- req$.internal$queryStringHandled
+  if (is.null(handled) || handled != TRUE){
+    qs <- req$QUERY_STRING
+    args <- parseQS(qs)
+    req$args <- c(req$args, args)
+    req$.internal$queryStringHandled <- TRUE
+  }
   forward()
 }
 

--- a/tests/testthat/helper-mock-request.R
+++ b/tests/testthat/helper-mock-request.R
@@ -1,8 +1,9 @@
 
-make_req <- function(verb, path){
+make_req <- function(verb, path, qs="", body=""){
   req <- new.env()
   req$REQUEST_METHOD <- toupper(verb)
   req$PATH_INFO <- path
-  req$rook.input <- list(read_lines = function(){ "" })
+  req$QUERY_STRING <- qs
+  req$rook.input <- list(read_lines = function(){ body })
   req
 }

--- a/tests/testthat/test-plumber.R
+++ b/tests/testthat/test-plumber.R
@@ -187,7 +187,7 @@ test_that("mounts work", {
   pr <- plumber$new()
   sub <- plumber$new()
   sub$handle("GET", "/", function(){ 1 })
-  sub$handle("GET", "/nested/path", function(){ 2 })
+  sub$handle("GET", "/nested/path", function(a){ a })
 
   pr$mount("/subpath", sub)
 
@@ -195,8 +195,11 @@ test_that("mounts work", {
   pr$route(make_req("GET", "/nested/path"), res)
   expect_equal(res$status, 404)
 
-  val <- pr$route(make_req("GET", "/subpath/nested/path"), PlumberResponse$new())
-  expect_equal(val, 2)
+  val <- pr$route(make_req("GET", "/subpath/nested/path", qs="?a=123"), PlumberResponse$new())
+  expect_equal(val, "123")
+
+  val <- pr$route(make_req("GET", "/subpath/nested/path", body='{"a":123}'), PlumberResponse$new())
+  expect_equal(val, 123)
 
   val <- pr$route(make_req("GET", "/subpath/"), PlumberResponse$new())
   expect_equal(val, 1)


### PR DESCRIPTION
Avoid duplicating arguments.