### PR TITLE
Fix swagger.json schema and suppress remote validation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@ plumber 0.4.3
 * BUGFIX: export `PlumberStatic`
 * Support query strings with keys that appear more than once 
   ([#165](https://github.com/trestletech/plumber/pull/165))
+* Fix the validation error warning at the bottom of deployed Swagger files 
+  which would have appeared any time your `swagger.json` file was hosted in
+  such a way that a hosted validator service would not have been able to access
+  it. For now we just suppress validation of swagger.json files. (#149)
 
 plumber 0.4.2
 --------------------------------------------------------------------------------

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -222,7 +222,7 @@ plumber <- R6Class(
         # Create a function that's hardcoded to return the swaggerfile -- regardless of env.
         fun <- function(schemes, host, path){
           if (!missing(schemes)){
-            sf$schemes <- schemes
+            sf$schemes <- I(schemes)
           }
 
           if (!missing(host)){

--- a/R/swagger.R
+++ b/R/swagger.R
@@ -78,9 +78,9 @@ extractSwaggerParams <- function(endpointParams, pathParams){
     }
 
     type <- endpointParams[[p]]$type
-    if (is.na(type)){
+    if (is.null(type) || is.na(type)){
       if (location == "path") {
-        type <- pathParams[pathParams$name == p,"type"]
+        type <- plumberToSwaggerType(pathParams[pathParams$name == p,"type"])
       } else {
         type <- "string" # Default to string
       }

--- a/R/swagger.R
+++ b/R/swagger.R
@@ -52,7 +52,7 @@ prepareSwaggerEndpoints <- function(routerEndpoints){
 
 defaultResp <- list("default"=list(description="Default response."))
 extractResponses <- function(resps){
-  if (is.null(resps)){
+  if (is.null(resps) || is.na(resps)){
     resps <- defaultResp
   } else if (!("default" %in% names(resps))){
     resps <- c(resps, defaultResp)

--- a/inst/swagger-ui/index.html
+++ b/inst/swagger-ui/index.html
@@ -79,8 +79,9 @@ window.onload = function() {
 
   var loc = window.location.href;
   if (loc.match(/\/__swagger__/)){
+    var protocol = window.location.protocol.replace(/:$/, '');
     loc = loc.replace(/__swagger__\/?/, 'swagger.json') + '?' +
-      'schemes=' + window.location.protocol +
+      'schemes=' + protocol +
       '&host=' + window.location.host +
       '&path=' + window.location.pathname.replace(/__swagger__\/?/, '');
   } else {

--- a/inst/swagger-ui/index.html
+++ b/inst/swagger-ui/index.html
@@ -100,7 +100,8 @@ window.onload = function() {
     plugins: [
       SwaggerUIBundle.plugins.DownloadUrl
     ],
-    layout: "StandaloneLayout"
+    layout: "StandaloneLayout",
+    validatorUrl: null,
   })
 
   window.ui = ui

--- a/tests/testthat/test-swagger.R
+++ b/tests/testthat/test-swagger.R
@@ -57,6 +57,10 @@ test_that("extractResponses works", {
   r <- extractResponses(NULL)
   expect_equal(r, defaultResp)
 
+  # Response constructor actually defaults to NA, so that's an important case, too
+  r <- extractResponses(NA)
+  expect_equal(r, defaultResp)
+
   # Responses with no default
   customResps <- list("200" = list())
   r <- extractResponses(customResps)

--- a/tests/testthat/test-swagger.R
+++ b/tests/testthat/test-swagger.R
@@ -67,8 +67,9 @@ test_that("extractResponses works", {
 
 test_that("extractSwaggerParams works", {
   ep <- list(id=list(desc="Description", type="integer", required=FALSE),
+             id2=list(desc="Description2", required=FALSE), # No redundant type specification
              make=list(desc="Make description", type="string", required=FALSE))
-  pp <- data.frame(name="id", type="int")
+  pp <- data.frame(name=c("id", "id2"), type=c("int", "int"))
 
   params <- extractSwaggerParams(ep, pp)
   expect_equal(as.list(params[1,]),
@@ -78,6 +79,12 @@ test_that("extractSwaggerParams works", {
                     required=TRUE, # Made required b/c path arg
                     type="integer"))
   expect_equal(as.list(params[2,]),
+               list(name="id2",
+                    description="Description2",
+                    `in`="path",
+                    required=TRUE, # Made required b/c path arg
+                    type="integer"))
+  expect_equal(as.list(params[3,]),
                list(name="make",
                     description="Make description",
                     `in`="query",
@@ -87,6 +94,7 @@ test_that("extractSwaggerParams works", {
   # If id were not a path param it should not be promoted to required
   params <- extractSwaggerParams(ep, NULL)
   expect_equal(params$required[params$name=="id"], FALSE)
+  expect_equal(params$type[params$name=="id"], "integer")
 
   params <- extractSwaggerParams(NULL, NULL)
   expect_equal(nrow(params), 0)


### PR DESCRIPTION
Fix the validation error warning at the bottom of deployed Swagger files 
  which would have appeared any time your `swagger.json` file was hosted in
  such a way that a hosted validator service would not have been able to access
  it. For now we just suppress validation of swagger.json files.

Closes #149 