### PR TITLE
Support onExit handler.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,9 @@ plumber 0.4.3
   which would have appeared any time your `swagger.json` file was hosted in
   such a way that a hosted validator service would not have been able to access
   it. For now we just suppress validation of swagger.json files. (#149)
+* Support a `plumber.onExit` option which can define a function that will be
+  evaluated when the API is interrupted. e.g. 
+  `options(plumber.onExit=function(){ print("Bye bye!") })`
 
 plumber 0.4.2
 --------------------------------------------------------------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@ plumber 0.4.3
   it. For now we just suppress validation of swagger.json files. (#149)
 * Support a `plumber.onExit` option which can define a function that will be
   evaluated when the API is interrupted. e.g. 
-  `options(plumber.onExit=function(){ print("Bye bye!") })`
+  `pr <- plumb("plumber.R"); pr$registerHook("exit", function(){ print("Bye bye!") })`
 
 plumber 0.4.2
 --------------------------------------------------------------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,7 @@ plumber 0.4.3
   which would have appeared any time your `swagger.json` file was hosted in
   such a way that a hosted validator service would not have been able to access
   it. For now we just suppress validation of swagger.json files. (#149)
-* Support a `plumber.onExit` option which can define a function that will be
+* Support an `exit` hook which can define a function that will be
   evaluated when the API is interrupted. e.g. 
   `pr <- plumb("plumber.R"); pr$registerHook("exit", function(){ print("Bye bye!") })`
 

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -196,7 +196,6 @@ plumber <- R6Class(
       on.exit({ options('plumber.debug' = getOption('plumber.debug')) })
       options(plumber.debug = debug)
 
-
       # Set and restore the wd to make it appear that the proc is running local to the file's definition.
       if (!is.null(private$filename)){
         cwd <- getwd()
@@ -246,6 +245,12 @@ plumber <- R6Class(
         self$mount("/__swagger__", plumberFileServer)
         message("Running the swagger UI at ", sf$schemes[1], "://", sf$host, "/__swagger__/", sep="")
       }
+
+      onex <- getOption("plumber.onExit", default=function(){})
+      if (!is.function(onex)){
+        stop("plumber.onExit option must be a function.")
+      }
+      on.exit(onex(), add=TRUE)
 
       httpuv::runServer(host, port, self)
     },

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -246,11 +246,7 @@ plumber <- R6Class(
         message("Running the swagger UI at ", sf$schemes[1], "://", sf$host, "/__swagger__/", sep="")
       }
 
-      onex <- getOption("plumber.onExit", default=function(){})
-      if (!is.function(onex)){
-        stop("plumber.onExit option must be a function.")
-      }
-      on.exit(onex(), add=TRUE)
+      on.exit(private$runHooks("exit"), add=TRUE)
 
       httpuv::runServer(host, port, self)
     },
@@ -260,7 +256,7 @@ plumber <- R6Class(
       private$mnts[[path]] <- router
     },
     registerHook = function(stage=c("preroute", "postroute",
-                                    "preserialize", "postserialize"), handler){
+                                    "preserialize", "postserialize", "exit"), handler){
       stage <- match.arg(stage)
       super$registerHook(stage, handler)
     },


### PR DESCRIPTION
Closes #198 

Set the `plumber.onExit` option to the function that you want evaluated when your API is exiting.