### PR TITLE
Support `.` in characters and negative numbers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@ plumber 0.4.3
   `pr <- plumb("plumber.R"); pr$registerHook("exit", function(){ print("Bye bye!") })`
 * Fixed bug in which a single function couldn't support multiple paths for a
   single verb (#203).
+* Support negative numbers in numeric path segments (#212)
+* Support `.` in string path segments
 
 plumber 0.4.2
 --------------------------------------------------------------------------------

--- a/R/query-string.R
+++ b/R/query-string.R
@@ -70,9 +70,9 @@ createPathRegex <- function(pathDef){
 }
 
 typeToRegex <- function(type){
-  re <- rep("[^\\\\./]+", length(type))
-  re[type == "int"] <- "\\\\d+"
-  re[type == "double" | type == "numeric"] <- "\\\\d*\\\\.?\\\\d*"
+  re <- rep("[^/]+", length(type))
+  re[type == "int"] <- "-?\\\\d+"
+  re[type == "double" | type == "numeric"] <- "-?\\\\d*\\\\.?\\\\d*"
   re[type == "bool" | type == "logical"] <- "[01tfTF]|true|false|TRUE|FALSE"
 
   re

--- a/R/query-string.R
+++ b/R/query-string.R
@@ -72,7 +72,7 @@ createPathRegex <- function(pathDef){
 typeToRegex <- function(type){
   re <- rep("[^/]+", length(type))
   re[type == "int"] <- "-?\\\\d+"
-  re[type == "double" | type == "numeric"] <- "-?\\\\d*\\\\.?\\\\d*"
+  re[type == "double" | type == "numeric"] <- "-?\\\\d*\\\\.?\\\\d+"
   re[type == "bool" | type == "logical"] <- "[01tfTF]|true|false|TRUE|FALSE"
 
   re

--- a/tests/testthat/files/path-params.R
+++ b/tests/testthat/files/path-params.R
@@ -3,6 +3,11 @@ function(id){
   id
 }
 
+#* @get /car/int/<id:int>
+function(id){
+  id
+}
+
 #* @get /car/<id>/sell/<price>
 function(id, price){
   list(id=id, price=price)

--- a/tests/testthat/test-path-subst.R
+++ b/tests/testthat/test-path-subst.R
@@ -26,11 +26,11 @@ test_that("variables are typed", {
 
   p <- createPathRegex("/car/<id:double>")
   expect_equal(p$names, "id")
-  expect_equal(p$regex, paste0("^/car/", "(-?\\d*\\.?\\d*)", "$"))
+  expect_equal(p$regex, paste0("^/car/", "(-?\\d*\\.?\\d+)", "$"))
 
   p <- createPathRegex("/car/<id:numeric>")
   expect_equal(p$names, "id")
-  expect_equal(p$regex, paste0("^/car/", "(-?\\d*\\.?\\d*)", "$"))
+  expect_equal(p$regex, paste0("^/car/", "(-?\\d*\\.?\\d+)", "$"))
 
   p <- createPathRegex("/car/<id:bool>")
   expect_equal(p$names, "id")
@@ -62,5 +62,13 @@ test_that("integration of path parsing works", {
                list(id=15, price="$15,000.99"))
   expect_equal(r$route(make_req("GET", "/car/ratio/1.5"), PlumberResponse$new()), 1.5)
   expect_equal(r$route(make_req("GET", "/car/ratio/-1.5"), PlumberResponse$new()), -1.5)
+  expect_equal(r$route(make_req("GET", "/car/ratio/-.5"), PlumberResponse$new()), -.5)
+  expect_equal(r$route(make_req("GET", "/car/ratio/.5"), PlumberResponse$new()), .5)
+  expect_equal(r$route(make_req("GET", "/car/ratio/a"), PlumberResponse$new()),
+               list(error = "404 - Resource Not Found"))
+  expect_equal(r$route(make_req("GET", "/car/ratio/"), PlumberResponse$new()),
+               list(error = "404 - Resource Not Found"))
+  expect_equal(r$route(make_req("GET", "/car/ratio/."), PlumberResponse$new()),
+               list(error = "404 - Resource Not Found"))
   expect_equal(r$route(make_req("GET", "/car/sold/true"), PlumberResponse$new()), TRUE)
 })

--- a/tests/testthat/test-path-subst.R
+++ b/tests/testthat/test-path-subst.R
@@ -1,7 +1,7 @@
 context("Paths")
 
 test_that("paths are properly converted", {
-  varRegex <- "([^\\./]+)"
+  varRegex <- "([^/]+)"
   p <- createPathRegex("/car/")
   expect_equal(p$names, character())
   expect_equal(p$regex, "^/car/$")
@@ -22,15 +22,15 @@ test_that("paths are properly converted", {
 test_that("variables are typed", {
   p <- createPathRegex("/car/<id:int>")
   expect_equal(p$names, "id")
-  expect_equal(p$regex, paste0("^/car/", "(\\d+)", "$"))
+  expect_equal(p$regex, paste0("^/car/", "(-?\\d+)", "$"))
 
   p <- createPathRegex("/car/<id:double>")
   expect_equal(p$names, "id")
-  expect_equal(p$regex, paste0("^/car/", "(\\d*\\.?\\d*)", "$"))
+  expect_equal(p$regex, paste0("^/car/", "(-?\\d*\\.?\\d*)", "$"))
 
   p <- createPathRegex("/car/<id:numeric>")
   expect_equal(p$names, "id")
-  expect_equal(p$regex, paste0("^/car/", "(\\d*\\.?\\d*)", "$"))
+  expect_equal(p$regex, paste0("^/car/", "(-?\\d*\\.?\\d*)", "$"))
 
   p <- createPathRegex("/car/<id:bool>")
   expect_equal(p$names, "id")
@@ -52,9 +52,15 @@ test_that("integration of path parsing works", {
   r <- plumber$new("files/path-params.R")
 
   expect_equal(r$route(make_req("GET", "/car/13"), PlumberResponse$new()), "13")
+  expect_equal(r$route(make_req("GET", "/car/int/13"), PlumberResponse$new()), 13)
+  expect_equal(r$route(make_req("GET", "/car/int/-13"), PlumberResponse$new()), -13)
   expect_equal(r$route(make_req("GET", "/car/15/sell/$15,000"), PlumberResponse$new()), list(id="15", price="$15,000"))
   expect_equal(r$route(make_req("POST", "/car/13"), PlumberResponse$new()), "13")
-  expect_equal(r$route(make_req("GET", "/car/15/buy/$15,000"), PlumberResponse$new()), list(id=15, price="$15,000"))
+  expect_equal(r$route(make_req("GET", "/car/15/buy/$15,000"), PlumberResponse$new()),
+               list(id=15, price="$15,000"))
+  expect_equal(r$route(make_req("GET", "/car/15/buy/$15,000.99"), PlumberResponse$new()),
+               list(id=15, price="$15,000.99"))
   expect_equal(r$route(make_req("GET", "/car/ratio/1.5"), PlumberResponse$new()), 1.5)
+  expect_equal(r$route(make_req("GET", "/car/ratio/-1.5"), PlumberResponse$new()), -1.5)
   expect_equal(r$route(make_req("GET", "/car/sold/true"), PlumberResponse$new()), TRUE)
 })


### PR DESCRIPTION
This is in relation to #212. I don't know how is your code coverage for tests, but it seems to pass. I was expecting to break more things, especially the `.` in characters since it was explicitly excluded. I'd be happy to change the pull request if needed.