### PR TITLE
cookie expires and max-age arguments format

### DIFF
--- a/R/response.R
+++ b/R/response.R
@@ -65,14 +65,14 @@ cookieToStr <- function(name, value, path, expiration=FALSE, http=FALSE, secure=
       expy <- now + expiration
       expyStr <- format(expy, format="%a, %e %b %Y %T", tz="GMT", usetz=TRUE)
 
-      str <- paste0(str, "Expires: ", expyStr, "; ")
-      str <- paste0(str, "Max-Age: ", expiration, "; ")
+      str <- paste0(str, "Expires= ", expyStr, "; ")
+      str <- paste0(str, "Max-Age= ", expiration, "; ")
     } else if (inherits(expiration, "POSIXt")){
       seconds <- difftime(expiration, Sys.time(), units="secs")
       # TODO: DRY
       expyStr <- format(expiration, format="%a, %e %b %Y %T", tz="GMT", usetz=TRUE)
-      str <- paste0(str, "Expires: ", expyStr, "; ")
-      str <- paste0(str, "Max-Age: ", as.integer(seconds), "; ")
+      str <- paste0(str, "Expires= ", expyStr, "; ")
+      str <- paste0(str, "Max-Age= ", as.integer(seconds), "; ")
     } # interpret all other values as session cookies.
   }
 

--- a/tests/testthat/test-cookies.R
+++ b/tests/testthat/test-cookies.R
@@ -43,11 +43,11 @@ test_that("cookies can convert to string", {
   # line above and below.
   # When given as a number of seconds
   expect_equal(cookieToStr("abc", 123, expiration=expiresSec),
-               paste0("abc=123; Expires: ", expyStr, "; Max-Age: ", expiresSec))
+               paste0("abc=123; Expires= ", expyStr, "; Max-Age= ", expiresSec))
   # When given as a POSIXct
   # difftime is exclusive, so the Max-Age may be off by one on positive time diffs.
   expect_equal(cookieToStr("abc", 123, expiration=expires),
-               paste0("abc=123; Expires: ", expyStr, "; Max-Age: ", expiresSec-1))
+               paste0("abc=123; Expires= ", expyStr, "; Max-Age= ", expiresSec-1))
 
   # Works with a negative number of seconds
   expiresSec <- -10
@@ -57,10 +57,10 @@ test_that("cookies can convert to string", {
   # line above and below.
   # When given as a number of seconds
   expect_equal(cookieToStr("abc", 123, expiration=expiresSec),
-               paste0("abc=123; Expires: ", expyStr, "; Max-Age: ", expiresSec))
+               paste0("abc=123; Expires= ", expyStr, "; Max-Age= ", expiresSec))
   # When given as a POSIXct
   expect_equal(cookieToStr("abc", 123, expiration=expires),
-               paste0("abc=123; Expires: ", expyStr, "; Max-Age: ", expiresSec))
+               paste0("abc=123; Expires= ", expyStr, "; Max-Age= ", expiresSec))
 })
 
 


### PR DESCRIPTION
Hi,
I corrected the cookie format to make its _expires_ and _max-age_ arguments work.
Regards