### PR TITLE
Add tags to swagger specification

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ Authors@R: c(
   person(family="Trestle Technology, LLC", role="aut", email="cran@trestletech.com"),
   person("Jeff", "Allen", role="cre", email="cran@trestletech.com"),
   person("Frans", "van Dunné", role="ctb", email="frans@ixpantia.com"),
+  person("Sebastiaan", "Vandewoude", role="ctb", email="sebastiaanvandewoude@me.com"),
   person(family="SmartBear Software", role=c("ctb", "cph"), comment="swagger-ui"))
 License: MIT + file LICENSE
 BugReports: https://github.com/trestletech/plumber/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R: c(
   person(family="Trestle Technology, LLC", role="aut", email="cran@trestletech.com"),
   person("Jeff", "Allen", role="cre", email="cran@trestletech.com"),
   person("Frans", "van Dunné", role="ctb", email="frans@ixpantia.com"),
-  person("Sebastiaan", "Vandewoude", role="ctb", email="sebastiaanvandewoude@me.com"),
+  person("Sebastiaan", "Vandewoude", role="ctb", email="sebastiaanvandewoude@gmail.com"),
   person(family="SmartBear Software", role=c("ctb", "cph"), comment="swagger-ui"))
 License: MIT + file LICENSE
 BugReports: https://github.com/trestletech/plumber/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 plumber 0.4.5
 --------------------------------------------------------------------------------
-* BUGFIX: properly handle cookie expiration values (#216).
+* BUGFIX: properly handle cookie expiration values ([#216](https://github.com/trestletech/plumber/issues/216)).
+* Add support for tags in Swagger docs ([#230](https://github.com/trestletech/plumber/pull/230)).
 
 plumber 0.4.4
 --------------------------------------------------------------------------------

--- a/R/parse-block.R
+++ b/R/parse-block.R
@@ -23,6 +23,7 @@ parseBlock <- function(lineNum, file){
   params <- NULL
   comments <- ""
   responses <- NULL
+  tags <- NULL
   while (lineNum > 0 && (stri_detect_regex(file[lineNum], pattern="^#['\\*]") || stri_trim_both(file[lineNum]) == "")){
 
     line <- file[lineNum]
@@ -179,6 +180,12 @@ parseBlock <- function(lineNum, file){
       params[[name]] <- list(desc=paramMat[1,5], type=type, required=reqd)
     }
 
+    tagMat <- stringi::stri_match(line, regex="^#['\\*]\\s*@tag\\s+(\\S.+)\\s*")
+    if (!is.na(tagMat[1,1])){
+      t <- stri_trim_both(tagMat[1,2])
+      tags <- c(tags, t)
+    }
+
     commentMat <- stringi::stri_match(line, regex="^#['\\*]\\s*([^@\\s].*$)")
     if (!is.na(commentMat[1,2])){
       comments <- paste(comments, commentMat[1,2])
@@ -197,7 +204,8 @@ parseBlock <- function(lineNum, file){
     assets = assets,
     params = params,
     comments = comments,
-    responses = responses
+    responses = responses,
+    tags = tags
   )
 }
 

--- a/R/parse-block.R
+++ b/R/parse-block.R
@@ -223,7 +223,7 @@ activateBlock <- function(srcref, file, expr, envir, addEndpoint, addFilter, mou
 
   if (!is.null(block$paths)){
     lapply(block$paths, function(p){
-      ep <- PlumberEndpoint$new(p$verb, p$path, expr, envir, block$serializer, srcref, block$params, block$comments, block$responses)
+      ep <- PlumberEndpoint$new(p$verb, p$path, expr, envir, block$serializer, srcref, block$params, block$comments, block$responses, block$tags)
 
       if (!is.null(block$image)){
         # Arguments to pass in to the image serializer

--- a/R/parse-block.R
+++ b/R/parse-block.R
@@ -182,7 +182,7 @@ parseBlock <- function(lineNum, file){
 
     tagMat <- stringi::stri_match(line, regex="^#['\\*]\\s*@tag\\s+(\\S.+)\\s*")
     if (!is.na(tagMat[1,1])){
-      t <- stri_trim_both(tagMat[1,2])
+      t <- gsub("_"," ",stri_trim_both(tagMat[1,2]))
       tags <- c(tags, t)
     }
 

--- a/R/parse-block.R
+++ b/R/parse-block.R
@@ -182,7 +182,7 @@ parseBlock <- function(lineNum, file){
 
     tagMat <- stringi::stri_match(line, regex="^#['\\*]\\s*@tag\\s+(\\S.+)\\s*")
     if (!is.na(tagMat[1,1])){
-      t <- gsub("_"," ",stri_trim_both(tagMat[1,2]))
+      t <- stri_trim_both(tagMat[1,2])
       if (is.na(t) || t == ""){
         stopOnLine(lineNum, line, "No tag specified.")
       }

--- a/R/parse-block.R
+++ b/R/parse-block.R
@@ -183,6 +183,12 @@ parseBlock <- function(lineNum, file){
     tagMat <- stringi::stri_match(line, regex="^#['\\*]\\s*@tag\\s+(\\S.+)\\s*")
     if (!is.na(tagMat[1,1])){
       t <- gsub("_"," ",stri_trim_both(tagMat[1,2]))
+      if (is.na(t) || t == ""){
+        stopOnLine(lineNum, line, "No tag specified.")
+      }
+      if (t %in% tags){
+        stopOnLine(lineNum, line, "Duplicate tag specified.")
+      }
       tags <- c(tags, t)
     }
 

--- a/R/parse-globals.R
+++ b/R/parse-globals.R
@@ -75,7 +75,7 @@ parseGlobals <- function(lines){
   fullArg <- ""
 
   # Build up the fields that we want to return as globals
-  fields <- list(info=list(),tags=data.frame())
+  fields <- list(info=list())
 
   # Parse the global docs
   for (line in lines){

--- a/R/parse-globals.R
+++ b/R/parse-globals.R
@@ -57,7 +57,7 @@ parseOneGlobal <- function(fields, argument){
          },
          apiTag={
            tagMat <- stringi::stri_match(def, regex="^\\s*(\\w+)\\s+(\\S.+)\\s*$")
-           name <- gsub("_"," ",tagMat[1,2])
+           name <- tagMat[1,2]
            description <- tagMat[1,3]
            fields$tags <- rbind(fields$tags,data.frame(name=name,description=description))
          })

--- a/R/parse-globals.R
+++ b/R/parse-globals.R
@@ -59,6 +59,9 @@ parseOneGlobal <- function(fields, argument){
            tagMat <- stringi::stri_match(def, regex="^\\s*(\\w+)\\s+(\\S.+)\\s*$")
            name <- tagMat[1,2]
            description <- tagMat[1,3]
+           if(!is.null(fields$tags) && name %in% fields$tags$name) {
+             stop("Error: '", argument, "' - ","Duplicate tag definition specified.")
+           }
            fields$tags <- rbind(fields$tags,data.frame(name=name, description=description, stringsAsFactors = FALSE))
          })
   fields

--- a/R/parse-globals.R
+++ b/R/parse-globals.R
@@ -59,7 +59,7 @@ parseOneGlobal <- function(fields, argument){
            tagMat <- stringi::stri_match(def, regex="^\\s*(\\w+)\\s+(\\S.+)\\s*$")
            name <- tagMat[1,2]
            description <- tagMat[1,3]
-           fields$tags <- rbind(fields$tags,data.frame(name=name,description=description))
+           fields$tags <- rbind(fields$tags,data.frame(name=name, description=description, stringsAsFactors = FALSE))
          })
   fields
 }

--- a/R/parse-globals.R
+++ b/R/parse-globals.R
@@ -57,7 +57,7 @@ parseOneGlobal <- function(fields, argument){
          },
          apiTag={
            tagMat <- stringi::stri_match(def, regex="^\\s*(\\w+)\\s+(\\S.+)\\s*$")
-           name <- tagMat[1,2]
+           name <- gsub("_"," ",tagMat[1,2])
            description <- tagMat[1,3]
            fields$tags <- rbind(fields$tags,data.frame(name=name,description=description))
          })

--- a/R/parse-globals.R
+++ b/R/parse-globals.R
@@ -54,6 +54,12 @@ parseOneGlobal <- function(fields, argument){
          },
          apiProduces={
            fields$produces <- strsplit(def, split="\\s+")[[1]]
+         },
+         apiTag={
+           tagMat <- stringi::stri_match(def, regex="^\\s*(\\w+)\\s+(\\S.+)\\s*$")
+           name <- tagMat[1,2]
+           description <- tagMat[1,3]
+           fields$tags <- rbind(fields$tags,data.frame(name=name,description=description))
          })
   fields
 }
@@ -69,7 +75,7 @@ parseGlobals <- function(lines){
   fullArg <- ""
 
   # Build up the fields that we want to return as globals
-  fields <- list(info=list())
+  fields <- list(info=list(),tags=data.frame())
 
   # Parse the global docs
   for (line in lines){

--- a/R/plumber-step.R
+++ b/R/plumber-step.R
@@ -99,12 +99,13 @@ PlumberEndpoint <- R6Class(
       data.frame(name=private$regex$names, type=private$regex$types)
     },
     params = NA,
+    tags = NA,
     canServe = function(req){
       req$REQUEST_METHOD %in% self$verbs && !is.na(stringi::stri_match(req$PATH_INFO, regex=private$regex$regex)[1,1])
     },
     # For historical reasons we have to accept multiple verbs for a single path. Now it's simpler
     # to just parse each separate verb/path into its own endpoint, so we just do that.
-    initialize = function(verbs, path, expr, envir, serializer, lines, params, comments, responses){
+    initialize = function(verbs, path, expr, envir, serializer, lines, params, comments, responses, tags){
       self$verbs <- verbs
       self$path <- path
 
@@ -132,6 +133,9 @@ PlumberEndpoint <- R6Class(
       }
       if (!missing(responses)){
         self$responses <- responses
+      }
+      if(!missing(tags) && !is.null(tags)){
+        self$tags <- tags
       }
     },
     getPathParams = function(path){

--- a/R/plumber-step.R
+++ b/R/plumber-step.R
@@ -137,7 +137,7 @@ PlumberEndpoint <- R6Class(
       if(!missing(tags) && !is.null(tags)){
         # make sure we box tags in json using I()
         # single tags should be converted to json as:
-        # tags: ["tagName"] and not tags: "tagNome"
+        # tags: ["tagName"] and not tags: "tagName"
         self$tags <- I(tags)
       }
     },

--- a/R/plumber-step.R
+++ b/R/plumber-step.R
@@ -135,7 +135,7 @@ PlumberEndpoint <- R6Class(
         self$responses <- responses
       }
       if(!missing(tags) && !is.null(tags)){
-        self$tags <- tags
+        self$tags <- I(tags)
       }
     },
     getPathParams = function(path){

--- a/R/plumber-step.R
+++ b/R/plumber-step.R
@@ -135,6 +135,9 @@ PlumberEndpoint <- R6Class(
         self$responses <- responses
       }
       if(!missing(tags) && !is.null(tags)){
+        # make sure we box tags in json using I()
+        # single tags should be converted to json as:
+        # tags: ["tagName"] and not tags: "tagNome"
         self$tags <- I(tags)
       }
     },

--- a/R/swagger.R
+++ b/R/swagger.R
@@ -40,7 +40,8 @@ prepareSwaggerEndpoints <- function(routerEndpoints){
 
         endptSwag <- list(summary=e$comments,
                           responses=resps,
-                          parameters=params)
+                          parameters=params,
+                          tags=e$tags)
 
         endpoints[[cleanedPath]][[tolower(verb)]] <- endptSwag
       }

--- a/inst/examples/11-car-inventory/plumber.R
+++ b/inst/examples/11-car-inventory/plumber.R
@@ -3,9 +3,12 @@ inventory <- read.csv("inventory.csv", stringsAsFactors = FALSE)
 #* @apiTitle Auto Inventory Manager
 #* @apiDescription Manage the inventory of an automobile
 #*   store using an API.
+#* @apiTag cars Functionality having to do with the management of
+#*   car inventory.
 
 #* List all cars in the inventory
 #* @get /car/
+#* @tag cars
 listCars <- function(){
   inventory
 }
@@ -14,6 +17,7 @@ listCars <- function(){
 #* @param id The ID of the car to get
 #* @get /car/<id:int>
 #* @response 404 No car with the given ID was found in the inventory.
+#* @tag cars
 getCar <- function(id, res){
   car <- inventory[inventory$id == id,]
   if (nrow(car) == 0){
@@ -44,6 +48,7 @@ validateCar <- function(make, model, year){
 #* @param miles:int The number of miles the car has
 #* @param price:numeric The price of the car in USD
 #* @response 400 Invalid user input provided
+#* @tag cars
 addCar <- function(make, model, edition, year, miles, price, res){
   newId <- max(inventory$id) + 1
 
@@ -76,6 +81,7 @@ addCar <- function(make, model, edition, year, miles, price, res){
 #* @param miles:int The number of miles the car has
 #* @param price:numeric The price of the car in USD
 #* @put /car/<id:int>
+#* @tag cars
 updateCar <- function(id, make, model, edition, year, miles, price, res){
 
   valid <- validateCar(make, model, year)
@@ -105,6 +111,7 @@ updateCar <- function(id, make, model, edition, year, miles, price, res){
 #* Delete a car from the inventory
 #* @param id:int The ID of the car to delete
 #* @delete /car/<id:int>
+#* @tag cars
 deleteCar <- function(id, res){
   if (!(id %in% inventory$id)){
     res$status <- 400

--- a/tests/testthat/test-globals.R
+++ b/tests/testthat/test-globals.R
@@ -51,3 +51,9 @@ test_that("parseGlobals works", {
     tags=data.frame(name=c("tag","tag2"),description=c("description","description2"), stringsAsFactors = FALSE)
   ))
 })
+
+test_that("Globals can't contain duplicate tags", {
+  lines <- c("#* @apiTag test description1",
+             "#* @apiTag test description2")
+  expect_error(parseGlobals(lines), "Duplicate tag definition specified.")
+})

--- a/tests/testthat/test-globals.R
+++ b/tests/testthat/test-globals.R
@@ -29,7 +29,8 @@ test_that("parseGlobals works", {
              "#' @apiSchemes schemes",
              "#' @apiConsumes consumes",
              "#' @apiProduces produces",
-             "#' @apiTag tag description")
+             "#' @apiTag tag description",
+             "#' @apiTag tag2 description2")
 
   fields <- parseGlobals(lines)
 
@@ -47,6 +48,6 @@ test_that("parseGlobals works", {
     schemes="schemes",
     consumes="consumes",
     produces="produces",
-    tags=data.frame(name="tag",description="description", stringsAsFactors = FALSE)
+    tags=data.frame(name=c("tag","tag2"),description=c("description","description2"), stringsAsFactors = FALSE)
   ))
 })

--- a/tests/testthat/test-globals.R
+++ b/tests/testthat/test-globals.R
@@ -28,7 +28,8 @@ test_that("parseGlobals works", {
              "#' @apiBasePath basepath",
              "#' @apiSchemes schemes",
              "#' @apiConsumes consumes",
-             "#' @apiProduces produces")
+             "#' @apiProduces produces",
+             "#' @apiTag tag description")
 
   fields <- parseGlobals(lines)
 
@@ -45,6 +46,7 @@ test_that("parseGlobals works", {
     basePath="basepath",
     schemes="schemes",
     consumes="consumes",
-    produces="produces"
+    produces="produces",
+    tags=data.frame(name="tag",description="description")
   ))
 })

--- a/tests/testthat/test-globals.R
+++ b/tests/testthat/test-globals.R
@@ -47,6 +47,6 @@ test_that("parseGlobals works", {
     schemes="schemes",
     consumes="consumes",
     produces="produces",
-    tags=data.frame(name="tag",description="description")
+    tags=data.frame(name="tag",description="description", stringsAsFactors = FALSE)
   ))
 })

--- a/tests/testthat/test-parse-block.R
+++ b/tests/testthat/test-parse-block.R
@@ -73,4 +73,10 @@ test_that("Block can't be multiple mutually exclusive things", {
 
 })
 
+test_that("Block can't contain duplicate tags", {
+  lines <- c("#* @tag test",
+            "#* @tag test")
+  expect_error(parseBlock(length(lines), lines), "Duplicate tag specified.")
+})
+
 # TODO: more testing around filter, assets, endpoint, etc.


### PR DESCRIPTION
Adding functionality to parse `tags` from plumber annotation and add to swagger-json.

Example:
```r
#* @apiTitle Tags Example
#* @apiTag name1 description1
#* @apiTag name2 description2
#* @apiTag name3_with_whitespaces description2


#* Example endpoint with one tag
#* @tag name1
#* @get /f1
function() {

}

#* Example endpoint with multiple tags
#* @tag name1
#* @tag name2
#* @get /f2
function() {}

#* Example endpoint with unmatched tags
#* @tag randomName
#* @get /f3
function() {}

#* Example endpoint with tag with whitespaces
#* @tag name3_with_whitespaces
#* @get /f4
function() {}
```

Which would create a swagger-ui with 4 tags:

- name1

   - /f1
   - /f2

- name2
   - /f2

- randomName
   - /f3

- name3 with whitepsace
   - /f4

Screenshot below:
![plumber-tags-exmaple](https://user-images.githubusercontent.com/4331075/35196887-728d7d9e-fed8-11e7-9754-ad0291f5a15f.png)
