### PR TITLE
Handle non base64 encoded javascript from pandoc

### DIFF
--- a/R/serializer-htmlwidget.R
+++ b/R/serializer-htmlwidget.R
@@ -22,7 +22,7 @@ serializer_htmlwidget <- function(){
       htmlwidgets::saveWidget(val, file, selfcontained=TRUE)
 
       # Read the file back in as a single string and return.
-      res$body <- paste(readLines(file), collapse="")
+      res$body <- paste(readLines(file), collapse="\n")
 
       # Delete the temp file
       file.remove(file)

--- a/tests/testthat/test-serializer-htmlwidgets.R
+++ b/tests/testthat/test-serializer-htmlwidgets.R
@@ -20,7 +20,7 @@ test_that("htmlwidgets serialize properly", {
   expect_equal(val$status, 200L)
   expect_equal(val$headers$`Content-Type`, "text/html; charset=utf-8")
   # Check that content is encoded
-  expect_match(val$body, "<script src=\"data:application/x-javascript;base64")
+  expect_match(val$body, "url\\(data:image/png;base64")
 })
 
 test_that("Errors call error handler", {

--- a/tests/testthat/test-serializer-htmlwidgets.R
+++ b/tests/testthat/test-serializer-htmlwidgets.R
@@ -20,7 +20,7 @@ test_that("htmlwidgets serialize properly", {
   expect_equal(val$status, 200L)
   expect_equal(val$headers$`Content-Type`, "text/html; charset=utf-8")
   # Check that content is encoded
-  expect_match(val$body, "url\\(data:image/png;base64")
+  expect_match(val$body, "url(data:image/png;base64", fixed = TRUE)
 })
 
 test_that("Errors call error handler", {


### PR DESCRIPTION
Javascript is not being encoded by default anymore. When reading the saved widget file, the new lines must be preserved to keep the javascript functioning.

In the tests, checking for base64 encoded images is still valid within the htmlwidgets test to make sure it is self contained.

Reference:
"SelfContained: don't use data URIs for script or style.": jgm/pandoc@7c0a80c