### PR TITLE
update to generate swagger docs for mounted routers

### DIFF
--- a/R/plumber.R
+++ b/R/plumber.R
@@ -676,19 +676,20 @@ plumber <- R6Class(
 
       private$ends[[preempt]] <- c(private$ends[[preempt]], ep)
     },
-    swaggerFileWalkMountsInternal = function(router, parentPath = ""){
+    swaggerFileWalkMountsInternal = function(router, parentPath=""){
 
       parentPath <- sub("[/]$", "", parentPath)
       endpoints <- lapply(router$endpoints, function(endpoint){
 
         endpointEntries <- lapply(endpoint, function(endpointEntry){
+          endpointEntry <- endpointEntry$clone()
           endpointPath <- sub("^[/]", "", endpointEntry$path)
           endpointPath <- paste(parentPath, endpointPath, sep="/")
           endpointEntry$path <- endpointPath
           endpointEntry
         })
         
-        endpoint
+        endpointEntries
       })
 
       mounts <- router$mounts

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -532,7 +532,30 @@ plumber <- R6Class(
       private$addFilterInternal(filter)
     },
     swaggerFile = function(){ #FIXME: test
-      endpoints <- prepareSwaggerEndpoints(self$endpoints)
+      endpoints <- self$endpoints
+
+      if (length(self$mounts) > 0){
+        for (path in names(self$mounts)){
+
+          mount <- self$mounts[[path]]
+          mount_endpoints <- mount$endpoints
+          path <- sub("[/]$", "", path)
+
+          if (length(mount_endpoints) > 0) {
+            mount_endpoints <- lapply(mount_endpoints, function(i){
+              i <- lapply(i, function(j){
+                subpath <- sub("^[/]", "", j$path)
+                j$path <- paste(path, subpath, sep="/")
+                j
+              })
+              i
+            })
+            
+            endpoints <- c(endpoints, mount_endpoints)
+          }
+        }
+      }
+      endpoints <- prepareSwaggerEndpoints(endpoints)
 
       # Extend the previously parsed settings with the endpoints
       def <- modifyList(private$globalSettings, list(paths=endpoints))

--- a/tests/testthat/test-swagger.R
+++ b/tests/testthat/test-swagger.R
@@ -52,6 +52,31 @@ test_that("params are parsed", {
 #test_that("prepareSwaggerEndpoints works", {
 #})
 
+test_that("swaggerFile works", {
+  pr <- plumber$new()
+  pr$handle("GET", "/nested/path/here", function(){})
+  pr$handle("POST", "/nested/path/here", function(){})
+
+  stat <- PlumberStatic$new(".")
+
+  pr2 <- plumber$new()
+  pr2$handle("POST", "/something", function(){})
+  pr2$handle("GET", "/", function(){})
+
+  pr3 <- plumber$new()
+  pr3$handle("POST", "/else", function(){})
+  pr3$handle("GET", "/", function(){})
+
+  pr$mount("/static", stat)
+  pr2$mount("/sub3", pr3)
+  pr$mount("/sub2", pr2)
+
+  paths <- names(pr$swaggerFile()$paths)
+  expect_length(paths, 5)
+  expect_equal(paths, c("/nested/path/here", "/sub2/something",
+    "/sub2/", "/sub2/sub3/else", "/sub2/sub3/"))
+})
+
 test_that("extractResponses works", {
   # Empty
   r <- extractResponses(NULL)


### PR DESCRIPTION
Hi,

I'm not sure if plumber is currently taking unsolicited PRs, but I'm new to both R and plumber and really wanted the automatic swagger doc generation to work with mounted routers. These changes seem to work for me (at least for walking this list of endpoints for the router children of the root router). Open to any/all feedback/criticism and happy to revise.

Thanks!

(I _think_ this addresses https://github.com/trestletech/plumber/issues/219)