### PR TITLE
Swagger support for recursive router mounts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,4 +64,4 @@ Collate:
     'serializer.R'
     'session-cookie.R'
     'swagger.R'
-RoxygenNote: 6.0.1.9000
+RoxygenNote: 6.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,4 +64,4 @@ Collate:
     'serializer.R'
     'session-cookie.R'
     'swagger.R'
-RoxygenNote: 6.0.1
+RoxygenNote: 6.0.1.9000

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 plumber 0.4.7
 --------------------------------------------------------------------------------
+* Add support for swagger for mounted routers ([#274](https://github.com/trestletech/plumber/issues/274)).
+
 
 plumber 0.4.6
 --------------------------------------------------------------------------------
@@ -11,7 +13,8 @@ plumber 0.4.6
 * Add support for tags in Swagger docs ([#230](https://github.com/trestletech/plumber/pull/230)).
 * Optional `swaggerCallback` parameter for `run()` to supply a callback function
   for reporting the url for swagger page.
-* Add [RStudio Project Template](https://rstudio.github.io/rstudio-extensions/rstudio_project_templates.html) to package
+* Add [RStudio Project Template](https://rstudio.github.io/rstudio-extensions/rstudio_project_templates.html) to package.
+
 
 plumber 0.4.4
 --------------------------------------------------------------------------------
@@ -47,11 +50,13 @@ plumber 0.4.4
 * Support negative numbers in numeric path segments (#212)
 * Support `.` in string path segments
 
+
 plumber 0.4.2
 --------------------------------------------------------------------------------
 * Development version for 0.4.2. Will be working to move to even/odd release
   cycles, but I had prematurely bumped to 0.4.0 so that one might get skipped,
   making the next CRAN release 0.4.2.
+
 
 plumber 0.4.0
 --------------------------------------------------------------------------------
@@ -96,10 +101,12 @@ plumber 0.4.0
 * Added a `debug` parameter to the `run` method which can be set to `TRUE` in
   order to get more insight into your API errors.
 
+
 plumber 0.3.3
 --------------------------------------------------------------------------------
 * `plumb()` now accepts an argument `dir`, referring to a directory containing
   `plumber.R`, which may be provided instead of `file`.
+
 
 plumber 0.3.2
 --------------------------------------------------------------------------------
@@ -114,10 +121,12 @@ plumber 0.3.2
 * Properly handle cookies with no value. (#88)
 * Don't convert `+` character in a query string to a space.
 
+
 plumber 0.3.1
 --------------------------------------------------------------------------------
 * Add a method to consume JSON on post (you can still send a query string in
   the body of a POST request as well).
+
 
 plumber 0.3.0
 --------------------------------------------------------------------------------
@@ -131,6 +140,7 @@ plumber 0.3.0
   will be passed in as an argument to the serializer factory. See example
   `09-content-type`.
 
+
 plumber 0.2.4
 --------------------------------------------------------------------------------
 * Add a filter which parses and sets req$cookies to be a list corresponding to
@@ -139,11 +149,13 @@ plumber 0.2.4
 * Bug Fix: convert non-character arguments in setCookie to character before URL-
   encoding.
 
+
 plumber 0.2.3
 --------------------------------------------------------------------------------
 * Set options(warn=1) during execution of user code so that warnings are
   immediately visible in the console, rather than storing them until the server
   is stopped.
+
 
 plumber 0.2.2
 --------------------------------------------------------------------------------
@@ -157,10 +169,12 @@ plumber 0.2.2
   and the endpoint.
 * Document all public params so CHECK passes
 
+
 plumber 0.2.1
 --------------------------------------------------------------------------------
 * Add more Roxygen documentation for exported functions
 * Remove the warning in the README as the API seems to be stabilizing.
+
 
 plumber 0.2.0
 --------------------------------------------------------------------------------
@@ -169,6 +183,7 @@ plumber 0.2.0
 * BREAKING: Renamed `PlumberRouter` R6 object to just `Plumber`.
 * Support `addEndpoint()` and `addFilter()` on the `Plumber` object.
 * Added support for the `#*` prefix.
+
 
 plumber 0.1.0
 --------------------------------------------------------------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 plumber 0.4.7
 --------------------------------------------------------------------------------
-* Add support for swagger for mounted routers ([#274](https://github.com/trestletech/plumber/issues/274)).
+* Add support for swagger for mounted routers (@bradleyhd, [#274](https://github.com/trestletech/plumber/issues/274)).
 
 
 plumber 0.4.6

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -676,19 +676,20 @@ plumber <- R6Class(
 
       private$ends[[preempt]] <- c(private$ends[[preempt]], ep)
     },
-    swaggerFileWalkMountsInternal = function(router, parentPath = ""){
+    swaggerFileWalkMountsInternal = function(router, parentPath=""){
 
       parentPath <- sub("[/]$", "", parentPath)
       endpoints <- lapply(router$endpoints, function(endpoint){
 
         endpointEntries <- lapply(endpoint, function(endpointEntry){
+          endpointEntry <- endpointEntry$clone()
           endpointPath <- sub("^[/]", "", endpointEntry$path)
           endpointPath <- paste(parentPath, endpointPath, sep="/")
           endpointEntry$path <- endpointPath
           endpointEntry
         })
         
-        endpoint
+        endpointEntries
       })
 
       mounts <- router$mounts

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -532,7 +532,30 @@ plumber <- R6Class(
       private$addFilterInternal(filter)
     },
     swaggerFile = function(){ #FIXME: test
-      endpoints <- prepareSwaggerEndpoints(self$endpoints)
+      endpoints <- self$endpoints
+
+      if (length(self$mounts) > 0){
+        for (path in names(self$mounts)){
+
+          mount <- self$mounts[[path]]
+          mount_endpoints <- mount$endpoints
+          path <- sub("[/]$", "", path)
+
+          if (length(mount_endpoints) > 0) {
+            mount_endpoints <- lapply(mount_endpoints, function(i){
+              i <- lapply(i, function(j){
+                subpath <- sub("^[/]", "", j$path)
+                j$path <- paste(path, subpath, sep="/")
+                j
+              })
+              i
+            })
+            
+            endpoints <- c(endpoints, mount_endpoints)
+          }
+        }
+      }
+      endpoints <- prepareSwaggerEndpoints(endpoints)
 
       # Extend the previously parsed settings with the endpoints
       def <- modifyList(private$globalSettings, list(paths=endpoints))

--- a/R/swagger.R
+++ b/R/swagger.R
@@ -17,34 +17,32 @@ plumberToSwaggerType <- function(type){
 #' Convert the endpoints as they exist on the router to a list which can
 #' be converted into a swagger definition for these endpoints
 #' @noRd
-prepareSwaggerEndpoints <- function(routerEndpoints){
+prepareSwaggerEndpoints <- function(routerEndpointEntries){
   endpoints <- list()
 
-  for (fil in routerEndpoints){
-    for (e in fil){
-      # TODO: we are sensitive to trailing slashes. Should we be?
-      cleanedPath <- gsub("<([^:>]+)(:[^>]+)?>", "{\\1}", e$path)
-      if (is.null(endpoints[[cleanedPath]])){
-        endpoints[[cleanedPath]] <- list()
-      }
+  for (e in routerEndpointEntries){
+    # TODO: we are sensitive to trailing slashes. Should we be?
+    cleanedPath <- gsub("<([^:>]+)(:[^>]+)?>", "{\\1}", e$path)
+    if (is.null(endpoints[[cleanedPath]])){
+      endpoints[[cleanedPath]] <- list()
+    }
 
-      # Get the params from the path
-      pathParams <- e$getTypedParams()
-      for (verb in e$verbs){
-        params <- extractSwaggerParams(e$params, pathParams)
+    # Get the params from the path
+    pathParams <- e$getTypedParams()
+    for (verb in e$verbs){
+      params <- extractSwaggerParams(e$params, pathParams)
 
-        # If we haven't already documented a path param, we should add it here.
-        # FIXME: warning("Undocumented path parameters: ", paste0())
+      # If we haven't already documented a path param, we should add it here.
+      # FIXME: warning("Undocumented path parameters: ", paste0())
 
-        resps <- extractResponses(e$responses)
+      resps <- extractResponses(e$responses)
 
-        endptSwag <- list(summary=e$comments,
-                          responses=resps,
-                          parameters=params,
-                          tags=e$tags)
+      endptSwag <- list(summary=e$comments,
+                        responses=resps,
+                        parameters=params,
+                        tags=e$tags)
 
-        endpoints[[cleanedPath]][[tolower(verb)]] <- endptSwag
-      }
+      endpoints[[cleanedPath]][[tolower(verb)]] <- endptSwag
     }
   }
 

--- a/man/do_configure_https.Rd
+++ b/man/do_configure_https.Rd
@@ -44,5 +44,5 @@ Your TLS certificate will be automatically renewed and deployed. It also
 opens port 443 in the firewall to allow incoming HTTPS traffic.
 
 Historically, HTTPS certificates required payment in advance. If you
-appreciate this service, consider \href{https://letsencrypt.org/donate/}{donating to the letsencryptproject}.
+appreciate this service, consider \href{https://letsencrypt.org/donate/}{donating to the letsencrypt project}.
 }

--- a/tests/testthat/test-swagger.R
+++ b/tests/testthat/test-swagger.R
@@ -52,6 +52,31 @@ test_that("params are parsed", {
 #test_that("prepareSwaggerEndpoints works", {
 #})
 
+test_that("swaggerFile works", {
+  pr <- plumber$new()
+  pr$handle("GET", "/nested/path/here", function(){})
+  pr$handle("POST", "/nested/path/here", function(){})
+
+  stat <- PlumberStatic$new(".")
+
+  pr2 <- plumber$new()
+  pr2$handle("POST", "/something", function(){})
+  pr2$handle("GET", "/", function(){})
+
+  pr3 <- plumber$new()
+  pr3$handle("POST", "/else", function(){})
+  pr3$handle("GET", "/", function(){})
+
+  pr$mount("/static", stat)
+  pr2$mount("/sub3", pr3)
+  pr$mount("/sub2", pr2)
+
+  paths <- names(pr$swaggerFile()$paths)
+  expect_length(paths, 5)
+  expect_equal(paths, c("/nested/path/here", "/sub2/something",
+    "/sub2/", "/sub2/sub3/else", "/sub2/sub3/"))
+})
+
 test_that("extractResponses works", {
   # Empty
   r <- extractResponses(NULL)


### PR DESCRIPTION
Continuation of #274 

Changed behavior of internal method to capture the endpoint entries and not the nested entries within the endpoint.  The names of the nested structure have meaning and should be done properly with a `flatten(pr)` method.  