### PR TITLE
We can now install plumber from CRAN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,7 @@ RUN apt-get update -qq && apt-get install -y \
   libssl-dev \
   libcurl4-gnutls-dev
 
-RUN R -e 'install.packages(c("devtools"))'
-
-RUN R -e 'devtools::install_github("trestletech/plumber")'
+RUN install2.r plumber
 
 EXPOSE 8000
 ENTRYPOINT ["R", "-e", "pr <- plumber::plumb(commandArgs()[4]); pr$run(host='0.0.0.0', port=8000)"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apt-get update -qq && apt-get install -y \
   libssl-dev \
   libcurl4-gnutls-dev
 
+## RUN R -e 'install.packages(c("devtools"))'
+## RUN R -e 'devtools::install_github("trestletech/plumber")'
 RUN install2.r plumber
 
 EXPOSE 8000


### PR DESCRIPTION
By installing plumber from CRAN in the Dockerfile we can make the image slightly smaller.