### PR TITLE
use inherits() and expect_is() rather than "xxx" %in% class(obj)

### DIFF
--- a/R/plumber.R
+++ b/R/plumber.R
@@ -54,7 +54,7 @@ plumb <- function(file, dir="."){
 
     # source returns a list with value and visible elements, we want the (visible) value object.
     pr <- x$value
-    if (!("plumber" %in% class(pr))){
+    if (!inherits(pr, "plumber")){
       stop("entrypoint.R must return a runnable Plumber router.")
     }
 
@@ -349,11 +349,11 @@ plumber <- R6Class(
               printNode(node[[i]], name, childPref, isLast = i == length(node))
             }
           }
-        } else if ("plumber" %in% class(node)){
+        } else if (inherits(node, "plumber")){
           cat(prefix, "\u251c\u2500\u2500/", name, "\n", sep="") # "+--"
           # It's a router, let it print itself
           print(node, prefix=childPref, topLevel=FALSE)
-        } else if ("PlumberEndpoint" %in% class(node)){
+        } else if (inherits(node, "PlumberEndpoint")){
           printEndpoints(prefix, name, node, isLast)
         } else {
           cat("??")

--- a/tests/testthat/test-plumber.R
+++ b/tests/testthat/test-plumber.R
@@ -133,8 +133,8 @@ test_that("routes can be constructed correctly", {
   pr$mount("/static", stat)
 
   expect_length(pr$routes, 3)
-  expect_true("plumberstatic" %in% class(pr$routes[["static"]]))
-  expect_true("plumber" %in% class(pr$routes[["mysubpath"]]))
+  expect_is(pr$routes[["static"]], "plumberstatic")
+  expect_is(pr$routes[["mysubpath"]], "plumber")
 
   # 2 endpoints at the same location (different verbs)
   expect_length(pr$routes$nested$path$here, 2)
@@ -154,8 +154,8 @@ test_that("mounts can be read correctly", {
   pr$mount("/static", stat)
 
   expect_length(pr$routes, 3)
-  expect_true("plumberstatic" %in% class(pr$mounts[["/static/"]]))
-  expect_true("plumber" %in% class(pr$mounts[["/mysubpath/"]]))
+  expect_is(pr$mounts[["/static/"]], "plumberstatic")
+  expect_is(pr$mounts[["/mysubpath/"]], "plumber")
 })
 
 test_that("prints correctly", {
@@ -275,7 +275,7 @@ test_that("preroute hook gets the right data", {
   rqst <- make_req("GET", "/")
 
   pr$registerHook("preroute", function(data, req, res){
-    expect_true("PlumberResponse" %in% class(res))
+    expect_is(res, "PlumberResponse")
     expect_equal(rqst, req)
     expect_true(is.environment(data))
   })
@@ -287,7 +287,7 @@ test_that("postroute hook gets the right data and can modify", {
   pr$handle("GET", "/abc", function(){ 123 })
 
   pr$registerHook("postroute", function(data, req, res, value){
-    expect_true("PlumberResponse" %in% class(res))
+    expect_is(res, "PlumberResponse")
     expect_equal(req$PATH_INFO, "/abc")
     expect_true(is.environment(data))
     expect_equal(value, 123)
@@ -302,7 +302,7 @@ test_that("preserialize hook gets the right data and can modify", {
   pr$handle("GET", "/abc", function(){ 123 })
 
   pr$registerHook("preserialize", function(data, req, res, value){
-    expect_true("PlumberResponse" %in% class(res))
+    expect_is(res, "PlumberResponse")
     expect_equal(req$PATH_INFO, "/abc")
     expect_true(is.environment(data))
     expect_equal(value, 123)
@@ -317,7 +317,7 @@ test_that("postserialize hook gets the right data and can modify", {
   pr$handle("GET", "/abc", function(){ 123 })
 
   pr$registerHook("postserialize", function(data, req, res, value){
-    expect_true("PlumberResponse" %in% class(res))
+    expect_is(res, "PlumberResponse")
     expect_equal(req$PATH_INFO, "/abc")
     expect_true(is.environment(data))
     expect_equal(as.character(value$body), "[123]")

--- a/tests/testthat/test-plumber.R
+++ b/tests/testthat/test-plumber.R
@@ -133,8 +133,8 @@ test_that("routes can be constructed correctly", {
   pr$mount("/static", stat)
 
   expect_length(pr$routes, 3)
-  expect_is(pr$routes[["static"]], "plumberstatic")
-  expect_is(pr$routes[["mysubpath"]], "plumber")
+  expect_s3_class(pr$routes[["static"]], "plumberstatic")
+  expect_s3_class(pr$routes[["mysubpath"]], "plumber")
 
   # 2 endpoints at the same location (different verbs)
   expect_length(pr$routes$nested$path$here, 2)
@@ -154,8 +154,8 @@ test_that("mounts can be read correctly", {
   pr$mount("/static", stat)
 
   expect_length(pr$routes, 3)
-  expect_is(pr$mounts[["/static/"]], "plumberstatic")
-  expect_is(pr$mounts[["/mysubpath/"]], "plumber")
+  expect_s3_class(pr$mounts[["/static/"]], "plumberstatic")
+  expect_s3_class(pr$mounts[["/mysubpath/"]], "plumber")
 })
 
 test_that("prints correctly", {
@@ -275,7 +275,7 @@ test_that("preroute hook gets the right data", {
   rqst <- make_req("GET", "/")
 
   pr$registerHook("preroute", function(data, req, res){
-    expect_is(res, "PlumberResponse")
+    expect_s3_class(res, "PlumberResponse")
     expect_equal(rqst, req)
     expect_true(is.environment(data))
   })
@@ -287,7 +287,7 @@ test_that("postroute hook gets the right data and can modify", {
   pr$handle("GET", "/abc", function(){ 123 })
 
   pr$registerHook("postroute", function(data, req, res, value){
-    expect_is(res, "PlumberResponse")
+    expect_s3_class(res, "PlumberResponse")
     expect_equal(req$PATH_INFO, "/abc")
     expect_true(is.environment(data))
     expect_equal(value, 123)
@@ -302,7 +302,7 @@ test_that("preserialize hook gets the right data and can modify", {
   pr$handle("GET", "/abc", function(){ 123 })
 
   pr$registerHook("preserialize", function(data, req, res, value){
-    expect_is(res, "PlumberResponse")
+    expect_s3_class(res, "PlumberResponse")
     expect_equal(req$PATH_INFO, "/abc")
     expect_true(is.environment(data))
     expect_equal(value, 123)
@@ -317,7 +317,7 @@ test_that("postserialize hook gets the right data and can modify", {
   pr$handle("GET", "/abc", function(){ 123 })
 
   pr$registerHook("postserialize", function(data, req, res, value){
-    expect_is(res, "PlumberResponse")
+    expect_s3_class(res, "PlumberResponse")
     expect_equal(req$PATH_INFO, "/abc")
     expect_true(is.environment(data))
     expect_equal(as.character(value$body), "[123]")


### PR DESCRIPTION
I think useing inherits() and expect_is() should be a better practice.