### PR TITLE
Accept NA handling arg for serializers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,8 @@ Imports:
     stringi (>= 0.3.0),
     jsonlite (>= 0.9.16),
     httpuv (>= 1.2.3),
-    crayon
+    crayon,
+    purrr (>= 0.2.0)
 LazyData: TRUE
 ByteCompile: TRUE
 Suggests:

--- a/R/serializer-json.R
+++ b/R/serializer-json.R
@@ -1,10 +1,11 @@
 #' @include globals.R
 #' @rdname serializers
 #' @export
-serializer_json <- function(){
-  function(val, req, res, errorHandler){
+serializer_json <- function(na = "null"){
+  purrr::partial(function(val, req, res, errorHandler, na){
+
     tryCatch({
-      json <- jsonlite::toJSON(val)
+      json <- jsonlite::toJSON(val, na = na)
 
       res$setHeader("Content-Type", "application/json")
       res$body <- json
@@ -13,17 +14,17 @@ serializer_json <- function(){
     }, error=function(e){
       errorHandler(req, res, e)
     })
-  }
+  }, na = na, .lazy = FALSE)
 }
 .globals$serializers[["json"]] <- serializer_json
 
 #' @include globals.R
 #' @rdname serializers
 #' @export
-serializer_unboxed_json <- function(){
-  function(val, req, res, errorHandler){
+serializer_unboxed_json <- function(na = "null"){
+  purrr::partial(function(val, req, res, errorHandler, na){
     tryCatch({
-      json <- jsonlite::toJSON(val, auto_unbox = TRUE)
+      json <- jsonlite::toJSON(val, na = na, auto_unbox = TRUE)
 
       res$setHeader("Content-Type", "application/json")
       res$body <- json
@@ -32,7 +33,7 @@ serializer_unboxed_json <- function(){
     }, error=function(e){
       errorHandler(req, res, e)
     })
-  }
+  }, na = na, .lazy = FALSE)
 }
 
 .globals$serializers[["unboxedJSON"]] <- serializer_unboxed_json

--- a/R/serializer-json.R
+++ b/R/serializer-json.R
@@ -1,5 +1,6 @@
 #' @include globals.R
 #' @rdname serializers
+#' @param na How should NA values be encoded?
 #' @export
 serializer_json <- function(na = "null"){
   purrr::partial(function(val, req, res, errorHandler, na){

--- a/man/serializers.Rd
+++ b/man/serializers.Rd
@@ -10,9 +10,9 @@
 \alias{serializers}
 \title{Plumber Serializers}
 \usage{
-serializer_json()
+serializer_json(na = "null")
 
-serializer_unboxed_json()
+serializer_unboxed_json(na = "null")
 
 serializer_content_type(type)
 

--- a/man/serializers.Rd
+++ b/man/serializers.Rd
@@ -22,6 +22,8 @@ serializer_htmlwidget()
 }
 \arguments{
 \item{type}{The value to provide for the \code{Content-Type} HTTP header.}
+\item{na}{How should NA values be encoded?}
+
 }
 \description{
 Serializers are used in Plumber to transform the R object produced by a

--- a/tests/testthat/test-parse-block.R
+++ b/tests/testthat/test-parse-block.R
@@ -79,4 +79,23 @@ test_that("Block can't contain duplicate tags", {
   expect_error(parseBlock(length(lines), lines), "Duplicate tag specified.")
 })
 
+test_that("@json works", {
+
+  lines <- c(
+    "#' @json")
+  b <- parseBlock(length(lines), lines)
+  expect_equal_functions(b$serializer, serializer_json())
+
+
+  lines <- c(
+    "#' @json(na = 'string')")
+  b <- parseBlock(length(lines), lines)
+  expect_equal_functions(b$serializer, serializer_json(na = 'string'))
+
+
+  lines <- c("#' @json(na = 'string'")
+  expect_error(parseBlock(length(lines), lines), "Supplemental arguments to the serializer")
+})
+
+
 # TODO: more testing around filter, assets, endpoint, etc.

--- a/tests/testthat/test-serializer-json.R
+++ b/tests/testthat/test-serializer-json.R
@@ -6,6 +6,18 @@ test_that("JSON serializes properly", {
   expect_equal(val$status, 200L)
   expect_equal(val$headers$`Content-Type`, "application/json")
   expect_equal(val$body, jsonlite::toJSON(l))
+
+  l <- list(a=1, b=2, c="hi", na=NA)
+  val <- serializer_json()(l, list(), PlumberResponse$new(), stop)
+  expect_equal(val$status, 200L)
+  expect_equal(val$headers$`Content-Type`, "application/json")
+  expect_equal(val$body, jsonlite::toJSON(l, na = 'null'))
+
+  l <- list(a=1, b=2, c="hi", na=NA)
+  val <- serializer_json(na = 'string')(l, list(), PlumberResponse$new(), stop)
+  expect_equal(val$status, 200L)
+  expect_equal(val$headers$`Content-Type`, "application/json")
+  expect_equal(val$body, jsonlite::toJSON(l, na = 'string'))
 })
 
 test_that("Errors call error handler", {
@@ -27,6 +39,19 @@ test_that("Unboxed JSON serializes properly", {
   expect_equal(val$status, 200L)
   expect_equal(val$headers$`Content-Type`, "application/json")
   expect_equal(val$body, jsonlite::toJSON(l, auto_unbox = TRUE))
+
+
+  l <- list(a=1, b=2, c="hi", na=NA)
+  val <- serializer_unboxed_json()(l, list(), PlumberResponse$new(), stop)
+  expect_equal(val$status, 200L)
+  expect_equal(val$headers$`Content-Type`, "application/json")
+  expect_equal(val$body, jsonlite::toJSON(l, auto_unbox = TRUE, na = 'null'))
+
+  l <- list(a=1, b=2, c="hi", na=NA)
+  val <- serializer_unboxed_json(na = 'string')(l, list(), PlumberResponse$new(), stop)
+  expect_equal(val$status, 200L)
+  expect_equal(val$headers$`Content-Type`, "application/json")
+  expect_equal(val$body, jsonlite::toJSON(l,  auto_unbox = TRUE, na = 'string'))
 })
 
 test_that("Unboxed JSON errors call error handler", {


### PR DESCRIPTION
Happy to receive any comments or feedback

This allows the use of `#' json(na = ...)` in a comment block, which is handled appropriately.  It requires the use of `purrr::partial` to apply the arguments, as otherwise the fact plumber uses R6 classes breaks relying on using simple closures.

This fixes #279 

I think this code could be generalised to allow specification of any `toJSON` arguments.