### PR TITLE
Removes the httpuv connection: close workaround

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     R6 (>= 2.0.0),
     stringi (>= 0.3.0),
     jsonlite (>= 0.9.16),
-    httpuv (>= 1.2.3),
+    httpuv (>= 1.4.0),
     crayon
 LazyData: TRUE
 ByteCompile: TRUE

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -498,10 +498,6 @@ plumber <- R6Class(
 
     # httpuv interface
     call = function(req){
-      # Due to https://github.com/rstudio/httpuv/issues/49, we need to close
-      # the TCP channels via `Connection: close` header. Otherwise we would
-      # reuse the same environment for each request and potentially recycle
-      # old data here.
       # Set the arguments to an empty list
       req$args <- list()
       req$.internal <- new.env()

--- a/R/response.R
+++ b/R/response.R
@@ -18,10 +18,6 @@ PlumberResponse <- R6Class(
       # httpuv doesn't like empty headers lists, and this is a useful field anyway...
       h$Date <- format(Sys.time(), "%a, %d %b %Y %X %Z", tz="GMT")
 
-      # Due to https://github.com/rstudio/httpuv/issues/49, we need each
-      # request to be on a separate TCP stream
-      h$Connection = "close"
-
       body <- self$body
       if (is.null(body)){
         body <- ""


### PR DESCRIPTION
This removes the workaround introduced in 4901c5e to avoid rstudio/httpuv#49, which has been fixed (in my estimation) since at least `httpuv` 1.4.0.

I've tentatively confirmed that environments are no longer shared between connections even when they are `keep-alive` by using the original integration test added in the referenced commit.

As a nice bonus, this improves `plumber`'s baseline latency by about 10% on my machine.