### PR TITLE
need to set the LC_TIME to C to ensure the Date is formatted in English

### DIFF
--- a/R/response.R
+++ b/R/response.R
@@ -17,10 +17,13 @@ PlumberResponse <- R6Class(
       h <- self$headers
       # httpuv doesn't like empty headers lists, and this is a useful field anyway...
       # need to set the LC_TIME to C to ensure the Date is formatted in English
-      old_lc_time <- Sys.getlocale("LC_TIME")
-      Sys.setlocale("LC_TIME", "C")
-      on.exit(Sys.setlocale("LC_TIME", old_lc_time), add = TRUE)
-      h$Date <- format(Sys.time(), "%a, %d %b %Y %X %Z", tz="GMT")
+      english_time <- function() {
+        old_lc_time <- Sys.getlocale("LC_TIME")
+        Sys.setlocale("LC_TIME", "C")
+        on.exit(Sys.setlocale("LC_TIME", old_lc_time), add = TRUE)
+        format(Sys.time(), "%a, %d %b %Y %X %Z", tz="GMT")
+      }
+      h$Date <- english_time()
 
       # Due to https://github.com/rstudio/httpuv/issues/49, we need each
       # request to be on a separate TCP stream

--- a/R/response.R
+++ b/R/response.R
@@ -16,6 +16,10 @@ PlumberResponse <- R6Class(
     toResponse = function(){
       h <- self$headers
       # httpuv doesn't like empty headers lists, and this is a useful field anyway...
+      # need to set the LC_TIME to C to ensure the Date is formatted in English
+      old_lc_time <- Sys.getlocale("LC_TIME")
+      Sys.setlocale("LC_TIME", "C")
+      on.exit(Sys.setlocale("LC_TIME", old_lc_time), add = TRUE)
       h$Date <- format(Sys.time(), "%a, %d %b %Y %X %Z", tz="GMT")
 
       # Due to https://github.com/rstudio/httpuv/issues/49, we need each

--- a/tests/testthat/test-response.R
+++ b/tests/testthat/test-response.R
@@ -38,3 +38,18 @@ test_that("can set multiple same-named headers", {
   expect_true(another)
 })
 
+test_that("http_date_string() returns the same result as in Locale C", {
+  english_time <- function(x) {
+    old_lc_time <- Sys.getlocale("LC_TIME")
+    Sys.setlocale("LC_TIME", "C")
+    on.exit(Sys.setlocale("LC_TIME", old_lc_time), add = TRUE)
+    format(x, "%a, %d %b %Y %X %Z", tz = "GMT")
+  }
+  x <- as.POSIXct("2018-01-01 01:00:00", tz = "Asia/Shanghai")
+  expect_equal(http_date_string(x), english_time(x))
+  # multiple values
+  x_all_months <- sprintf("2018-%02d-03 12:00:00", 1:12)
+  x_all_weeks <- sprintf("2018-01-%02d 12:00:00", 1:7)
+  x <- as.POSIXct(c(x_all_months, x_all_weeks), tz = "Asia/Shanghai")
+  expect_equal(http_date_string(x), english_time(x))
+})


### PR DESCRIPTION
Hi, the `PlumberResponse` will attach `Date` to the header. However, the output of the below line will be different on a different computer (see the example below), which is problematic because normally the non-English date will not be parsed correctly (for example, [httr will parse the date as NA](https://github.com/r-lib/httr/pull/544))...

With this PR, we can ensure the date is always in English.

https://github.com/trestletech/plumber/blob/8c25b8bfba9774bd422022dc29662ffc17e170bc/R/response.R#L19


### The example

``` r
date_fmt <- function() {
  cat("Previous: ", format(Sys.time(), "%a, %d %b %Y %X %Z", tz="GMT"))
  cat("\n")
  old_lc_time <- Sys.getlocale("LC_TIME")
  Sys.setlocale("LC_TIME", "C")
  on.exit(Sys.setlocale("LC_TIME", old_lc_time), add = TRUE)
  cat("Now: ", format(Sys.time(), "%a, %d %b %Y %X %Z", tz="GMT"))
}
date_fmt()
#> Previous:  周五, 12 十月 2018 7:04:22 GMT
#> Now:  Fri, 12 Oct 2018 07:04:22 GMT
```

<sup>Created on 2018-10-12 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>
