### PR TITLE
fix #322 by recursively removing NULL/NA fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 .idea
 plumber.Rcheck
 plumber_*.tar.gz
+*.rxproj
+*.sln
+.vs/
+misc/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Suggests:
     htmlwidgets,
     visNetwork,
     analogsea
-Collate:
+Collate: 
     'content-types.R'
     'cookie-parser.R'
     'parse-globals.R'
@@ -64,4 +64,4 @@ Collate:
     'serializer.R'
     'session-cookie.R'
     'swagger.R'
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0.9000

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -541,7 +541,7 @@ plumber <- R6Class(
 
       # Lay those over the default globals so we ensure that the required fields
       # (like API version) are satisfied.
-      modifyList(defaultGlobals, def)
+      removeNulls(modifyList(defaultGlobals, def))
     },
 
     ### Legacy/Deprecated

--- a/R/swagger.R
+++ b/R/swagger.R
@@ -101,3 +101,25 @@ extractSwaggerParams <- function(endpointParams, pathParams){
   }
   params
 }
+
+
+#' Remove nulls from swagger definition:
+#' see https://github.com/swagger-api/swagger-js/issues/268
+#' @noRd
+removeNulls <- function(lst){
+
+  # recursively remove nulls (including NAs which will be translated to
+  # nulls by jsonlite::toJSON)
+  rmNaOrNull <- function(lst){
+    if(is.list(lst)){
+      null <- sapply(lst, function(x) all(is.na(x)) || is.null(x))
+      lst <- lst[!null]
+
+      lapply(lst, rmNaOrNull)
+    } else {
+      lst
+    }
+  }
+
+  rmNaOrNull(lst)
+}


### PR DESCRIPTION
Solution complicated by the fact that nulls can also be generated by NAs. Will also remove a blank `host` field from the generated Swagger file, which is arguably the right thing to do.

I got a bunch of failures on running `devtools::check()`, most likely because I don't have all the suggested packages installed. I only change the `swaggerFile()` method though, so all other functionality should be unaffected.