### PR TITLE
moved definition of private to initialize method in plumber object to…

### DIFF
--- a/R/plumber.R
+++ b/R/plumber.R
@@ -168,6 +168,10 @@ plumber <- R6Class(
       }
 
 
+      # These are initialized here to prevent them being locked by R6
+      private$errorHandler <- defaultErrorHandler()
+      private$notFoundHandler <- default404Handler
+      private$serializer = serializer_json()
 
       # Add in the initial filters
       for (fn in names(filters)){
@@ -175,10 +179,8 @@ plumber <- R6Class(
         private$filts <- c(private$filts, fil)
       }
 
-      # These are initialized here to prevent them being locked by R6
-      private$errorHandler <- defaultErrorHandler()
-      private$notFoundHandler <- default404Handler
-      private$serializer = serializer_json()
+
+
 
       if (!is.null(file)){
         private$lines <- readUTF8(file)

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -167,20 +167,16 @@ plumber <- R6Class(
         filters <- list()
       }
 
-
-      # These are initialized here to prevent them being locked by R6
+      # Initialize
       private$errorHandler <- defaultErrorHandler()
       private$notFoundHandler <- default404Handler
-      private$serializer = serializer_json()
+      private$serializer <- serializer_json()
 
       # Add in the initial filters
       for (fn in names(filters)){
         fil <- PlumberFilter$new(fn, filters[[fn]], private$envir, private$serializer, NULL)
         private$filts <- c(private$filts, fil)
       }
-
-
-
 
       if (!is.null(file)){
         private$lines <- readUTF8(file)

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -167,14 +167,18 @@ plumber <- R6Class(
         filters <- list()
       }
 
+
+
       # Add in the initial filters
       for (fn in names(filters)){
         fil <- PlumberFilter$new(fn, filters[[fn]], private$envir, private$serializer, NULL)
         private$filts <- c(private$filts, fil)
       }
 
+      # These are initialized here to prevent them being locked by R6
       private$errorHandler <- defaultErrorHandler()
       private$notFoundHandler <- default404Handler
+      private$serializer = serializer_json()
 
       if (!is.null(file)){
         private$lines <- readUTF8(file)
@@ -630,7 +634,7 @@ plumber <- R6Class(
       paths
     }
   ), private = list(
-    serializer = serializer_json(), # The default serializer for the router
+    serializer = NULL, # The default serializer for the router
 
     ends = list(), # List of endpoints indexed by their pre-empted filter.
     filts = NULL, # Array of filters


### PR DESCRIPTION
… prevent locking

This brings the serializer in line with the `private$errorHandler` and `private$notFoundHandler` in the plumber class in that they are defined during initialization rather than as part of the R6 definition (which appears to lock any functions)

This fixes https://github.com/trestletech/plumber/issues/339



