### PR TITLE
appveyor pkg cache will bust when DESCRIPTION changes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   ps: Bootstrap
 
 cache:
-  - C:\RLibrary
+  - C:\RLibrary -> DESCRIPTION
 
 # Adapt as necessary starting from here
 


### PR DESCRIPTION
https://www.appveyor.com/docs/build-cache/#cache-dependencies

Was running to a missing SHA error as the branch was removed (but not the commit)