### PR TITLE
Remove the Date header as httpuv does this automatically now

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     R6 (>= 2.0.0),
     stringi (>= 0.3.0),
     jsonlite (>= 0.9.16),
-    httpuv (>= 1.4.5.9000),
+    httpuv (>= 1.4.5.9002),
     crayon
 LazyData: TRUE
 ByteCompile: TRUE

--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,7 @@ plumber 0.5.0
 
 * Bumped version of httpuv to >= 1.4.5.9000 to address an unexpected segfault (@shapenaji, [#289](https://github.com/trestletech/plumber/issues/289))
 
+* Date response header is now supplied by httpuv and not plumber. Fixes non standard date response header issues when using different locales. (@shrektan, [#319](https://github.com/trestletech/plumber/pull/319), [#380](https://github.com/trestletech/plumber/pull/380))
 
 
 plumber 0.4.6

--- a/R/response.R
+++ b/R/response.R
@@ -1,25 +1,3 @@
-#' HTTP Date String
-#'
-#' Given a POSIXct object, return a date string in the format required for a
-#' HTTP Date header. For example: "Wed, 21 Oct 2015 07:28:00 GMT"
-#'
-#' @noRd
-http_date_string <- function(time) {
-  weekday_names <- c("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat")
-  weekday_num <- as.integer(strftime(time, format = "%w", tz = "GMT")) + 1L
-  weekday_name <- weekday_names[weekday_num]
-
-  month_names <- c("Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
-  month_num <- as.integer(strftime(time, format = "%m", tz = "GMT"))
-  month_name <- month_names[month_num]
-
-  strftime(
-    time,
-    paste0(weekday_name, ", %d ", month_name, " %Y %H:%M:%S GMT"),
-    tz = "GMT"
-  )
-}
 
 PlumberResponse <- R6Class(
   "PlumberResponse",
@@ -38,7 +16,6 @@ PlumberResponse <- R6Class(
     },
     toResponse = function(){
       h <- self$headers
-      h$Date <- http_date_string(Sys.time())
 
       body <- self$body
       if (is.null(body)){

--- a/tests/testthat/test-response.R
+++ b/tests/testthat/test-response.R
@@ -37,19 +37,3 @@ test_that("can set multiple same-named headers", {
   expect_true(test)
   expect_true(another)
 })
-
-test_that("http_date_string() returns the same result as in Locale C", {
-  english_time <- function(x) {
-    old_lc_time <- Sys.getlocale("LC_TIME")
-    Sys.setlocale("LC_TIME", "C")
-    on.exit(Sys.setlocale("LC_TIME", old_lc_time), add = TRUE)
-    format(x, "%a, %d %b %Y %X %Z", tz = "GMT")
-  }
-  x <- as.POSIXct("2018-01-01 01:00:00", tz = "Asia/Shanghai")
-  expect_equal(http_date_string(x), english_time(x))
-  # multiple values
-  x_all_months <- sprintf("2018-%02d-03 12:00:00", 1:12)
-  x_all_weeks <- sprintf("2018-01-%02d 12:00:00", 1:7)
-  x <- as.POSIXct(c(x_all_months, x_all_weeks), tz = "Asia/Shanghai")
-  expect_equal(http_date_string(x), english_time(x))
-})


### PR DESCRIPTION
Fixes #378
Fixes #319

The `Date` header is being published by httpuv automatically.  No need to do this manually.

https://github.com/rstudio/httpuv/commit/8bdeea2ff0667ca96ec1a5560284caf6a0702058