### PR TITLE
Add Promises with Domain

### DIFF
--- a/R/async.R
+++ b/R/async.R
@@ -3,7 +3,7 @@ runStepsIfForwarding <- function(initialValue, errorHandlerStep, steps) {
   runStepsUntil(
     initialValue = initialValue,
     errorHandlerStep = errorHandlerStep,
-    conditionFn = function(x) {
+    conditionFn = function(value) {
       !has_forwarded()
     },
     steps = steps
@@ -66,6 +66,7 @@ runStepsUntil <- function(initialValue, errorHandlerStep, conditionFn, steps) {
     res <- nextStep(x)
     if (is.promising(res)) {
       res %...>% (function(value) {
+        # message("WAITED!")
         x <<- value
         if (conditionFn(x)) {
           return(x)
@@ -132,6 +133,23 @@ runStepsUntil <- function(initialValue, errorHandlerStep, conditionFn, steps) {
 # )
 #
 # runStep(steps_two); print("END")
+
+
+currentExecName <- "currentExec"
+getCurrentExec <- function() {
+  .globals[[currentExecName]]
+}
+withCurrentExecDomain <- function(req, res, expr) {
+  # Create a new environment for this particular request/response
+  execEnv <- new.env(parent = emptyenv())
+  execEnv$req <- req
+  execEnv$res <- res
+
+  domain <- createVarPromiseDomain(.globals, currentExecName, execEnv)
+  promises::with_promise_domain(domain, expr)
+}
+
+
 
 # From Shiny.
 # Creates a promise domain that always ensures `env[[name]] == value` when

--- a/R/async.R
+++ b/R/async.R
@@ -4,7 +4,7 @@ runStepsIfForwarding <- function(initialValue, errorHandlerStep, steps) {
     initialValue = initialValue,
     errorHandlerStep = errorHandlerStep,
     conditionFn = function(x) {
-      !is_forward(x)
+      !has_forwarded()
     },
     steps = steps
   )
@@ -132,3 +132,40 @@ runStepsUntil <- function(initialValue, errorHandlerStep, conditionFn, steps) {
 # )
 #
 # runStep(steps_two); print("END")
+
+# From Shiny.
+# Creates a promise domain that always ensures `env[[name]] == value` when
+# any code is being run in this domain.
+createVarPromiseDomain <- function(env, name, value) {
+  force(env)
+  force(name)
+  force(value)
+
+  promises::new_promise_domain(
+    wrapOnFulfilled = function(onFulfilled) {
+      function(...) {
+        orig <- env[[name]]
+        env[[name]] <- value
+        on.exit(env[[name]] <- orig)
+
+        onFulfilled(...)
+      }
+    },
+    wrapOnRejected = function(onRejected) {
+      function(...) {
+        orig <- env[[name]]
+        env[[name]] <- value
+        on.exit(env[[name]] <- orig)
+
+        onRejected(...)
+      }
+    },
+    wrapSync = function(expr) {
+      orig <- env[[name]]
+      env[[name]] <- value
+      on.exit(env[[name]] <- orig)
+
+      force(expr)
+    }
+  )
+}

--- a/R/plumber-step.R
+++ b/R/plumber-step.R
@@ -9,10 +9,15 @@ forward_class <- "plumber_forward"
 #' request.
 #' @export
 forward <- function() {
-  structure(forward_class, class = forward_class)
+  exec <- getCurrentExec()
+  exec$forward <- TRUE
 }
-is_forward <- function(x) {
-  inherits(x, forward_class)
+has_forwarded <- function() {
+  getCurrentExec()$forward
+}
+reset_forward <- function() {
+  exec <- getCurrentExec()
+  exec$forward <- FALSE
 }
 
 PlumberStep <- R6Class(

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -538,6 +538,7 @@ plumber <- R6Class(
 
       makeHandleStep <- function(name) {
         function(...) {
+          reset_forward()
           h <- getHandle(name)
           if (is.null(h)) {
             return(forward())
@@ -607,6 +608,7 @@ plumber <- R6Class(
       mountSteps <- lapply(names(private$mnts), function(mountPath) {
         # (make step function)
         function(...) {
+          reset_forward()
           # TODO: support globbing?
 
           if (nchar(path) >= nchar(mountPath) && substr(path, 0, nchar(mountPath)) == mountPath) {

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -572,7 +572,7 @@ plumber <- R6Class(
             do.call(fi$exec, req$args)
           }
           postFilterStep <- function(fres, ...) {
-            if (!has_forwarded()) {
+            if (has_forwarded()) {
               # return like normal
               return(fres)
             }

--- a/R/plumber.R
+++ b/R/plumber.R
@@ -866,21 +866,3 @@ plumber <- R6Class(
     }
   )
 )
-
-hasPromises <- function(){
-  !!requireNamespace("promises", quietly = TRUE)
-}
-
-withCurrentExecDomain <- function(req, res, expr) {
-  # Create a new environment for this particular request/response
-  execEnv <- new.env(parent = emptyenv())
-  execEnv$req <- req
-  execEnv$res <- res
-
-  domain <- createVarPromiseDomain(.globals, "currentExec", execEnv)
-  promises::with_promise_domain(domain, expr)
-}
-
-getCurrentExec <- function() {
-  .globals[["currentExec"]]
-}


### PR DESCRIPTION
Add `createVarPromiseDomain` to get a domain specific piece of information for a current execution.  This helps solve the issue of `forward()` setting a `.globals$forward` flag, which would not work when performing async operations.