### PR TITLE
Support around non-ASCII key values in query string

### DIFF
--- a/R/query-string.R
+++ b/R/query-string.R
@@ -27,10 +27,18 @@ parseQS <- function(qs){
     return(list())
   }
 
-  keys <- decodeURI(vapply(kv, "[[", character(1), 1))
+  keys <- decodeURI(vapply(kv, "[[", character(1), 1)) # returns utf8 strings
+  if (any(Encoding(keys) != "unknown")) {
+    # https://github.com/trestletech/plumber/pull/314#discussion_r239992879
+    non_ascii <- setdiff(unique(Encoding(keys)), "unknown")
+    warning(
+      "Query string parameter received in non-ASCII encoding. Received: ",
+      paste0(non_ascii, collapse = ", ")
+    )
+  }
 
   vals <- vapply(kv, "[[", character(1), 2)
-  vals <- decodeURI(vals)
+  vals <- decodeURI(vals) # returns utf8 strings
 
   ret <- as.list(vals)
   names(ret) <- keys

--- a/tests/testthat/files/query-with-multibytes.R
+++ b/tests/testthat/files/query-with-multibytes.R
@@ -1,0 +1,5 @@
+#* @get /msg
+#* @post /msg
+function(param1, param2) {
+  paste(param1, param2, sep = "-")
+}

--- a/tests/testthat/test-query-with-multibytes.R
+++ b/tests/testthat/test-query-with-multibytes.R
@@ -1,0 +1,16 @@
+context("test-query-with-multibytes")
+
+test_that("Support multi-bytes queries", {
+  r <- plumber$new(test_path("files/query-with-multibytes.R"))
+  res <- PlumberResponse$new()
+
+  req <- make_req("GET", "/msg", "?param1=%E4%B8%AD%E6%96%87&param2=%E4%BD%A0%E5%A5%BD")
+  out <- r$serve(req, res)$body
+  expect_equal(Encoding(out), "UTF-8")
+  expect_identical(charToRaw(out), charToRaw(jsonlite::toJSON("\u4e2d\u6587-\u4f60\u597d")))
+
+  req <- make_req("POST", "/msg", "?param1=%E4%B8%AD%E6%96%87&param2=%E4%BD%A0%E5%A5%BD")
+  out <- r$serve(req, res)$body
+  expect_equal(Encoding(out), "UTF-8")
+  expect_identical(charToRaw(out), charToRaw(jsonlite::toJSON("\u4e2d\u6587-\u4f60\u597d")))
+})

--- a/tests/testthat/test-querystring.R
+++ b/tests/testthat/test-querystring.R
@@ -26,7 +26,12 @@ test_that("query strings with duplicates are made into vectors", {
 })
 
 test_that("parseQS() will mark UTF-8 explicitly", {
-  out <- parseQS("%E5%8F%82%E6%95%B01=%E4%B8%AD%E6%96%87")
+  expect_warning(
+    {
+      out <- parseQS("%E5%8F%82%E6%95%B01=%E4%B8%AD%E6%96%87")
+    },
+    "received in non-ASCII encoding"
+  )
   expect_equal(Encoding(names(out)), "UTF-8")
   expect_identical(
     charToRaw(names(out)),

--- a/tests/testthat/test-querystring.R
+++ b/tests/testthat/test-querystring.R
@@ -24,3 +24,17 @@ test_that("incomplete query strings are ignored", {
 test_that("query strings with duplicates are made into vectors", {
   expect_equal(parseQS("a=1&a=2&a=3&a=4"), list(a=c("1", "2", "3", "4")))
 })
+
+test_that("parseQS() will mark UTF-8 explicitly", {
+  out <- parseQS("%E5%8F%82%E6%95%B01=%E4%B8%AD%E6%96%87")
+  expect_equal(Encoding(names(out)), "UTF-8")
+  expect_identical(
+    charToRaw(names(out)),
+    as.raw(c(0xe5, 0x8f, 0x82, 0xe6, 0x95, 0xb0, 0x31))
+  )
+  expect_identical(
+    charToRaw(out[[1L]]),
+    as.raw(c(0xe4, 0xb8, 0xad, 0xe6, 0x96, 0x87))
+  )
+  expect_equal(Encoding(out[[1L]]), "UTF-8")
+})


### PR DESCRIPTION
Fixes #314

If non ASCII values are received, a warning is emitted.

Great testing provided by @shrektan 