### PR TITLE
Find function when only name is provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@
 plumber.Rcheck
 plumber_*.tar.gz
 yarn.lock
-node_modules/*
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ jobs:
       r: oldrel
       if: |
         repo = trestletech/plumber AND
+        type = push AND
         branch IN (master, travis, rc-v0.5.0)
       addons:
         apt:
@@ -58,6 +59,7 @@ jobs:
       r: oldrel
       if: |
         repo = trestletech/plumber AND
+        type = push AND
         branch IN (master, travis, rc-v0.5.0)
     - <<: *osx
       name: macOS - release

--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,8 @@ plumber 0.5.0
 
 ### Bug fixes
 
+* Fixed bug where functions defined earlier in the file could not be found when `plumb()`ing a file.  ([#416](https://github.com/trestletech/plumber/pull/416))
+
 * A multiline POST body is now collapsed to a single line (@robertdj, [#270](https://github.com/trestletech/plumber/issues/270) [#297](https://github.com/trestletech/plumber/pull/297)).
 
 * Bumped version of httpuv to >= 1.4.5.9000 to address an unexpected segfault (@shapenaji, [#289](https://github.com/trestletech/plumber/issues/289))

--- a/R/plumber-step.R
+++ b/R/plumber-step.R
@@ -46,7 +46,7 @@ PlumberStep <- R6Class(
     },
     exec = function(...) {
       allArgs <- list(...)
-      args <- getRelevantArgs(allArgs, plumberExpression=private$expr)
+      args <- getRelevantArgs(allArgs, plumberExpression=private$func)
 
       hookEnv <- new.env()
 


### PR DESCRIPTION
Use the evaluated function not the raw expression.

# Testing Notes

```r
remotes::install_github("trestletech/plumber#416")
p <- callr::r_bg(
  function(){ 
tmp <- tempfile(fileext = ".R")
cat(file = tmp, '
api_msg <- function(msg = "") {
  list(msg = paste0("The message is: \\"", msg, "\\""))
}

# API ----
#* @apiTitle Simple Plumber API

#* Echo back the input
#* @param msg The message to echo
#* @get /echo
api_msg
')

plumber::plumb(tmp)$run(port = 1234)
  }
)

Sys.sleep(1)
x <- httr::GET("127.0.0.1:1234/echo?msg=asdf")
print(httr::content(x))
#> $msg
#> $msg[[1]]
#> [1] "The message is: \"asdf\""
p$kill()
```