### PR TITLE
Work around `cloud-init` which clobbers /etc/apt/sources.list after s…

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@
 ^node_modules
 ^package\.json$
 ^\.github
+^\.httr-oauth$

--- a/R/digital-ocean.R
+++ b/R/digital-ocean.R
@@ -127,11 +127,12 @@ install_nginx <- function(droplet){
 }
 
 install_new_r <- function(droplet){
-  analogsea::droplet_ssh(droplet, c("echo 'deb https://cran.rstudio.com/bin/linux/ubuntu xenial/' >> /etc/apt/sources.list",
-                  "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9"))
+  analogsea::droplet_ssh(droplet, "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9")
+  analogsea::droplet_ssh(droplet, "echo 'deb https://cran.rstudio.com/bin/linux/ubuntu xenial/' >> /etc/apt/sources.list.d/cran.list")
   # TODO: use the analogsea version once https://github.com/sckott/analogsea/issues/139 is resolved
   #analogsea::debian_apt_get_update(droplet)
-  analogsea::droplet_ssh(droplet, "sudo apt-get update -qq", 'sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade')
+  analogsea::droplet_ssh(droplet, "sudo apt-get update -qq")
+  analogsea::droplet_ssh(droplet, 'sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade')
 
   analogsea::debian_install_r(droplet)
 }


### PR DESCRIPTION
…ome number of seconds.

The edits we were making to add the CRAN repo were getting clobbered.

We also separated into multiple separate SSH commands, though we don't believe that this is actually necessary.
